### PR TITLE
Fixes bug where UNDO command requires additional space after the word…

### DIFF
--- a/Parser/Parser.cpp
+++ b/Parser/Parser.cpp
@@ -72,6 +72,6 @@ bool Parser::isEditCommand(std::string& userInput) {
 }
 
 bool Parser::isUndoCommand(std::string& userInput) {
-	return std::regex_match(userInput, std::regex("undo.{1,}",
+	return std::regex_match(userInput, std::regex("undo.*",
 		std::regex_constants::ECMAScript | std::regex_constants::icase ));
 }


### PR DESCRIPTION
… "undo"
