### PR TITLE
Fixes memory allocation bug; implements tests

### DIFF
--- a/Parser/CommandTokens.h
+++ b/Parser/CommandTokens.h
@@ -76,6 +76,7 @@ private:
 };
 
 class CommandDoesNotExistException: public std::exception {
+public:
 	virtual const char* what() const throw() override {
 		return "Command does not exist";
 	}

--- a/Parser/Parser.cpp
+++ b/Parser/Parser.cpp
@@ -1,15 +1,5 @@
 #include <assert.h>
 #include "Parser.h"
-#include "AddCommandTokeniser.h"
-#include "CompleteCommandTokeniser.h"
-#include "DeleteCommandTokeniser.h"
-#include "DisplayCommandTokeniser.h"
-#include "ExportCommandTokeniser.h"
-#include "EditCommandTokeniser.h"
-#include "RefreshCommandTokeniser.h"
-#include "TagCommandTokeniser.h"
-#include "UndoCommandTokeniser.h"
-#include "UntagCommandTokeniser.h"
 
 Parser::Parser(void) {
 	_logger = Logger::getInstance();
@@ -22,98 +12,44 @@ Parser::Parser(void) {
 CommandTokens Parser::parse(std::string userInput) {
 	_logger->logINFO("Parsing user input: " + userInput);
 
-	// inclusion guard
-	CommandTokens::PrimaryCommandType primaryCommandType = getPrimaryCommand(userInput);
-	if (primaryCommandType == CommandTokens::PrimaryCommandType::Invalid) {
+	try {
+		selectCommandTokeniser(userInput);
+	}
+	catch (CommandDoesNotExistException& e) {
+		_logger->logINFO(e.what());
 		return _invalidCommandTokens;
 	}
-
-	initialiseCommandTokeniser(primaryCommandType);
 
 	return _commandTokeniser->tokeniseUserInput(userInput);
 }
 
-CommandTokens::PrimaryCommandType Parser::getPrimaryCommand(std::string userInput) {
-	CommandTokens::PrimaryCommandType primaryCommandType;
-	try {
-		primaryCommandType = parsePrimaryCommand(userInput);
-	} catch (CommandDoesNotExistException& e) {
-		_logger->logINFO(e.what());
-		primaryCommandType = CommandTokens::PrimaryCommandType::Invalid;
-	}
-	return primaryCommandType;
-}
-
-void Parser::initialiseCommandTokeniser(CommandTokens::PrimaryCommandType primaryCommandType) {
-	// inclusion guard in calling function should have dealt with Invalid commands
-	assert(primaryCommandType != CommandTokens::PrimaryCommandType::Invalid);
-
-	switch (primaryCommandType) {
-		case CommandTokens::PrimaryCommandType::Add:
-			_commandTokeniser = new AddCommandTokeniser;
-			break;
-		case CommandTokens::PrimaryCommandType::Complete:
-			_commandTokeniser = new CompleteCommandTokeniser;
-			break;
-		case CommandTokens::PrimaryCommandType::Delete:
-			_commandTokeniser = new DeleteCommandTokeniser;
-			break;
-		case CommandTokens::PrimaryCommandType::Display:
-			_commandTokeniser = new DisplayCommandTokeniser;
-			break;
-		case CommandTokens::PrimaryCommandType::Edit:
-			_commandTokeniser = new EditCommandTokeniser;
-			break;
-		case CommandTokens::PrimaryCommandType::Export:
-			_commandTokeniser = new ExportCommandTokeniser;
-			break;
-		case CommandTokens::PrimaryCommandType::Refresh:
-			_commandTokeniser = new RefreshCommandTokeniser;
-			break;
-		case CommandTokens::PrimaryCommandType::Tag:
-			_commandTokeniser = new TagCommandTokeniser;
-			break;
-		case CommandTokens::PrimaryCommandType::Undo:
-			_commandTokeniser = new UndoCommandTokeniser;
-			break;
-		case CommandTokens::PrimaryCommandType::Untag:
-			_commandTokeniser = new UntagCommandTokeniser;
-			break;
-		default:
-			// default should not be reached because of inclusion guard in
-			// calling function and assertion in this function
-			return;
-	}
-}
-
-CommandTokens::PrimaryCommandType Parser::parsePrimaryCommand(std::string userInput) {
+void Parser::selectCommandTokeniser(std::string userInput) {
 	CommandTokens::PrimaryCommandType commandType;
 
 	if (isAddCommand(userInput)) {
-		commandType = CommandTokens::PrimaryCommandType::Add;
+		_commandTokeniser = &_addCommandTokeniser;
 	} else if (isCompleteCommand(userInput)) {
-		commandType = CommandTokens::PrimaryCommandType::Complete;
+		_commandTokeniser = &_completeCommandTokeniser;
 	} else if (isDeleteCommand(userInput)) {
-		commandType = CommandTokens::PrimaryCommandType::Delete;
+		_commandTokeniser = &_deleteCommandTokeniser;
 	} else if (isDisplayCommand(userInput)) {
-		commandType = CommandTokens::PrimaryCommandType::Display;
+		_commandTokeniser = &_displayCommandTokeniser;
 	} else if (isEditCommand(userInput)) {
-		commandType = CommandTokens::PrimaryCommandType::Edit;
+		_commandTokeniser = &_editCommandTokeniser;
 	} else if (isExportCommand(userInput)) {
-		commandType = CommandTokens::PrimaryCommandType::Export;
+		_commandTokeniser = &_exportCommandTokeniser;
 	} else if (isRefreshCommand(userInput)) {
-		commandType = CommandTokens::PrimaryCommandType::Refresh;
+		_commandTokeniser = &_refreshCommandTokeniser;
 	} else if (isTagCommand(userInput)) {
-		commandType = CommandTokens::PrimaryCommandType::Tag;
+		_commandTokeniser = &_tagCommandTokeniser;
 	} else if (isUndoCommand(userInput)) {
-		commandType = CommandTokens::PrimaryCommandType::Undo;
+		_commandTokeniser = &_undoCommandTokeniser;
 	} else if (isUntagCommand(userInput)) {
-		commandType = CommandTokens::PrimaryCommandType::Untag;
+		_commandTokeniser = &_untagCommandTokeniser;
 	} else {
+		_commandTokeniser = nullptr;
 		throw CommandDoesNotExistException();
 	}
-
-	return commandType;
 }
 
 bool Parser::isAddCommand(std::string& userInput) {
@@ -152,6 +88,6 @@ bool Parser::isUndoCommand(std::string& userInput) {
 	return UndoCommandTokeniser::isUndoCommand(userInput);
 }
 
-bool Parser::isUntagCommand(std::string & userInput) {
+bool Parser::isUntagCommand(std::string& userInput) {
 	return UntagCommandTokeniser::isUntagCommand(userInput);
 }

--- a/Parser/Parser.cpp
+++ b/Parser/Parser.cpp
@@ -38,6 +38,7 @@ CommandTokens::PrimaryCommandType Parser::getPrimaryCommand(std::string userInpu
 	try {
 		primaryCommandType = parsePrimaryCommand(userInput);
 	} catch (CommandDoesNotExistException& e) {
+		_logger->logINFO(e.what());
 		primaryCommandType = CommandTokens::PrimaryCommandType::Invalid;
 	}
 	return primaryCommandType;

--- a/Parser/Parser.h
+++ b/Parser/Parser.h
@@ -3,6 +3,16 @@
 #include "CommandTokens.h"
 #include "CommandTokeniser.h"
 #include "Logger\Logger.h"
+#include "AddCommandTokeniser.h"
+#include "CompleteCommandTokeniser.h"
+#include "DeleteCommandTokeniser.h"
+#include "DisplayCommandTokeniser.h"
+#include "ExportCommandTokeniser.h"
+#include "EditCommandTokeniser.h"
+#include "RefreshCommandTokeniser.h"
+#include "TagCommandTokeniser.h"
+#include "UndoCommandTokeniser.h"
+#include "UntagCommandTokeniser.h"
 
 // tokenises user input for Logic to do the necessary processing
 class Parser {
@@ -14,15 +24,22 @@ private:
 	CommandTokeniser* _commandTokeniser;
 	CommandTokens _invalidCommandTokens;
 
+	AddCommandTokeniser _addCommandTokeniser;
+	CompleteCommandTokeniser _completeCommandTokeniser;
+	DeleteCommandTokeniser _deleteCommandTokeniser;
+	DisplayCommandTokeniser _displayCommandTokeniser;
+	ExportCommandTokeniser _exportCommandTokeniser;
+	EditCommandTokeniser _editCommandTokeniser;
+	RefreshCommandTokeniser _refreshCommandTokeniser;
+	TagCommandTokeniser _tagCommandTokeniser;
+	UndoCommandTokeniser _undoCommandTokeniser;
+	UntagCommandTokeniser _untagCommandTokeniser;
+
+
 	Logger* _logger;
 
-	// extracts the primary command word
-	CommandTokens::PrimaryCommandType getPrimaryCommand(std::string userInput);
-	CommandTokens::PrimaryCommandType parsePrimaryCommand(std::string userInput);
-	void initialiseCommandTokeniser(CommandTokens::PrimaryCommandType primaryCommandType);
+	void selectCommandTokeniser(std::string userInput);
 
-	// examines the extracted primary command word extracted by
-	// parsePrimaryCommand()
 	bool isAddCommand(std::string& userInput);
 	bool isCompleteCommand(std::string& userInput);
 	bool isDeleteCommand(std::string& userInput);
@@ -31,6 +48,6 @@ private:
 	bool isExportCommand(std::string& userInput);
 	bool isRefreshCommand(std::string& userInput);
 	bool isTagCommand(std::string& userInput);
-	bool isUndoCommand(std::string& userInput);	
+	bool isUndoCommand(std::string& userInput);
 	bool isUntagCommand(std::string& userInput);
 };

--- a/ParserTest/ParserTest.cpp
+++ b/ParserTest/ParserTest.cpp
@@ -249,6 +249,70 @@ namespace ParserTest {
 			compareCommandTokens(expected, actual);
 		}
 
+		TEST_METHOD(testTokeniseRefreshCommand) {
+			std::string testUserInput = "REFRESH";
+			CommandTokens actual, expected;
+			actual = _parser.parse(testUserInput);
+			expected = buildExpectedCommandTokens(CommandTokens::PrimaryCommandType::Refresh,
+			                                      CommandTokens::SecondaryCommandType::None,
+			                                      "",
+			                                      "",
+			                                      "",
+			                                      -1);
+
+			compareCommandTokens(expected, actual);
+		}
+
+		TEST_METHOD(testTokeniseTagCommand) {
+			std::string testUserInput = "TAG 19 #123 #abc";
+			CommandTokens actual, expected;
+			actual = _parser.parse(testUserInput);
+			expected = buildExpectedCommandTokens(CommandTokens::PrimaryCommandType::Tag,
+			                                      CommandTokens::SecondaryCommandType::Index,
+			                                      "",
+			                                      "",
+			                                      "",
+			                                      19);
+			std::vector< std::string > newTags;
+			newTags.push_back("#123");
+			newTags.push_back("#abc");
+			expected.setTags(newTags);
+
+			compareCommandTokens(expected, actual);
+		}
+
+		TEST_METHOD(testTokeniseUndoCommand) {
+			std::string testUserInput = "UNDO";
+			CommandTokens actual, expected;
+			actual = _parser.parse(testUserInput);
+			expected = buildExpectedCommandTokens(CommandTokens::PrimaryCommandType::Undo,
+			                                      CommandTokens::SecondaryCommandType::None,
+			                                      "",
+			                                      "",
+			                                      "",
+			                                      -1);
+
+			compareCommandTokens(expected, actual);
+		}
+
+		TEST_METHOD(testTokeniseUntagCommand) {
+			std::string testUserInput = "UNTAG 23 #12c #ab3";
+			CommandTokens actual, expected;
+			actual = _parser.parse(testUserInput);
+			expected = buildExpectedCommandTokens(CommandTokens::PrimaryCommandType::Untag,
+			                                      CommandTokens::SecondaryCommandType::Index,
+			                                      "",
+			                                      "",
+			                                      "",
+			                                      23);
+			std::vector< std::string > newTags;
+			newTags.push_back("#12c");
+			newTags.push_back("#ab3");
+			expected.setTags(newTags);
+
+			compareCommandTokens(expected, actual);
+		}
+
 		TEST_METHOD(testDateParser_DD_MM_YYYY_HHHH) {
 			std::string testUserInputDate = "13-05-1999 1320";
 			DateParser dateParser;


### PR DESCRIPTION
- fixes bug where dynamic allocation of CommandTokenisers cause weird jump of control in the switch statements
- implements unit tests for REFRESH, TAG, UNTAG, and UNDO parsing
