### PR TITLE
Refactors CommandTokeniser abstract class

### DIFF
--- a/Parser/CommandTokeniser.cpp
+++ b/Parser/CommandTokeniser.cpp
@@ -5,7 +5,6 @@ CommandTokeniser::CommandTokeniser(void) {
 	// nothing here
 }
 
-
 CommandTokeniser::~CommandTokeniser(void) {
 	// nothing here
 }

--- a/Parser/CommandTokeniser.cpp
+++ b/Parser/CommandTokeniser.cpp
@@ -9,14 +9,6 @@ CommandTokeniser::~CommandTokeniser(void) {
 	// nothing here
 }
 
-CommandTokens CommandTokeniser::tokeniseUserInput(std::string userInput) {
-	// nothing here, to be implemented by subclasses
-	// this function not made pure virtual because the function in Parser needs to
-	// return a CommandTokeniser, which cannot be an abstract class
-
-	return CommandTokens();
-}
-
 boost::posix_time::ptime CommandTokeniser::parseUserInputDate(std::string userInputDate) {
 	return _dateParser.parse(userInputDate);
 }

--- a/Parser/CommandTokeniser.cpp
+++ b/Parser/CommandTokeniser.cpp
@@ -1,3 +1,4 @@
+//@@ author A0097681N
 #include "CommandTokeniser.h"
 
 CommandTokeniser::CommandTokeniser(void) {

--- a/Parser/CommandTokeniser.h
+++ b/Parser/CommandTokeniser.h
@@ -1,3 +1,4 @@
+//@@ author A0097681N
 #pragma once
 #include <regex>
 #include "CommandTokens.h"

--- a/Parser/CommandTokeniser.h
+++ b/Parser/CommandTokeniser.h
@@ -12,7 +12,6 @@ public:
 	virtual bool isValidCommand(std::string userInput) = 0;
 
 protected:
-	CommandTokens _commandTokens;
 	DateParser _dateParser;
 	boost::posix_time::ptime parseUserInputDate(std::string userInputDate);
 };

--- a/Parser/CommandTokeniser.h
+++ b/Parser/CommandTokeniser.h
@@ -8,8 +8,9 @@ class CommandTokeniser {
 public:
 	CommandTokeniser(void);
 	virtual ~CommandTokeniser(void);
-	virtual CommandTokens tokeniseUserInput(std::string userInput);
-	virtual bool isValidCommand(std::string userInput) = 0;
+
+	virtual CommandTokens tokeniseUserInput(std::string userInput) = 0;
+	virtual bool canTokeniseUserInput(std::string userInput) = 0;
 
 protected:
 	DateParser _dateParser;

--- a/Parser/CommandTokeniser.h
+++ b/Parser/CommandTokeniser.h
@@ -8,6 +8,7 @@ public:
 	CommandTokeniser(void);
 	virtual ~CommandTokeniser(void);
 	virtual CommandTokens tokeniseUserInput(std::string userInput);
+	virtual bool isValidCommand(std::string userInput) = 0;
 
 protected:
 	CommandTokens _commandTokens;

--- a/Parser/CommandTokenisers/AddCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/AddCommandTokeniser.cpp
@@ -9,14 +9,11 @@ AddCommandTokeniser::~AddCommandTokeniser(void) {
 }
 
 bool AddCommandTokeniser::isValidCommand(std::string userInput) {
-	return isAddCommand(userInput);
-}
-
-bool AddCommandTokeniser::isAddCommand(std::string userInput) {
-	if (isAddActivityCommand(userInput) || isAddTodoCommand(userInput) || isAddFloatingCommand(userInput)) {
+	if (isAddFromTo(userInput) ||
+		isAddBy(userInput) ||
+		isAddFloating(userInput)) {
 		return true;
 	}
-
 	return false;
 }
 
@@ -29,11 +26,11 @@ CommandTokens AddCommandTokeniser::tokeniseUserInput(std::string userInput) {
 		userInput = trimTags(userInput);
 	}
 
-	if (isAddActivityCommand(userInput)) {
+	if (isAddFromTo(userInput)) {
 		tokeniseAddActivityCommand(userInput);
-	} else if (isAddTodoCommand(userInput)) {
+	} else if (isAddBy(userInput)) {
 		tokeniseAddTodoCommand(userInput);
-	} else if (isAddFloatingCommand(userInput)) {
+	} else if (isAddFloating(userInput)) {
 		tokeniseAddFloatingCommand(userInput);
 	}
 
@@ -53,21 +50,21 @@ bool AddCommandTokeniser::hasTags(std::string userInput) {
 
 // returns true if userInput contains "from" and subsequently "to";
 // case-insensitive
-bool AddCommandTokeniser::isAddActivityCommand(std::string userInput) {
+bool AddCommandTokeniser::isAddFromTo(std::string userInput) {
 	return std::regex_match(userInput,
 	                        std::regex("add .+ from .+ to .+",
 	                                   std::regex_constants::ECMAScript | std::regex_constants::icase));
 }
 
 // returns true if userInput contains "by"; case-insensitive
-bool AddCommandTokeniser::isAddTodoCommand(std::string userInput) {
+bool AddCommandTokeniser::isAddBy(std::string userInput) {
 	return std::regex_match(userInput,
 	                        std::regex("add .+ by .+",
 	                                   std::regex_constants::ECMAScript | std::regex_constants::icase));
 }
 
 // returns true if userInput contains "by"; case-insensitive
-bool AddCommandTokeniser::isAddFloatingCommand(std::string userInput) {
+bool AddCommandTokeniser::isAddFloating(std::string userInput) {
 	return std::regex_match(userInput,
 	                        std::regex("add .+",
 	                                   std::regex_constants::ECMAScript | std::regex_constants::icase));

--- a/Parser/CommandTokenisers/AddCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/AddCommandTokeniser.cpp
@@ -9,7 +9,7 @@ AddCommandTokeniser::~AddCommandTokeniser(void) {
 	// nothing here
 }
 
-bool AddCommandTokeniser::isValidCommand(std::string userInput) {
+bool AddCommandTokeniser::canTokeniseUserInput(std::string userInput) {
 	if (isAddFromTo(userInput) ||
 		isAddBy(userInput) ||
 		isAddFloating(userInput)) {
@@ -19,7 +19,7 @@ bool AddCommandTokeniser::isValidCommand(std::string userInput) {
 }
 
 CommandTokens AddCommandTokeniser::tokeniseUserInput(std::string userInput) {
-	assert(isValidCommand(userInput));
+	assert(canTokeniseUserInput(userInput));
 
 	CommandTokens tokenisedCommand(CommandTokens::PrimaryCommandType::Add);
 

--- a/Parser/CommandTokenisers/AddCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/AddCommandTokeniser.cpp
@@ -1,3 +1,4 @@
+//@@ author A0097681N
 #include "AddCommandTokeniser.h"
 
 AddCommandTokeniser::AddCommandTokeniser(void) {

--- a/Parser/CommandTokenisers/AddCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/AddCommandTokeniser.cpp
@@ -8,6 +8,10 @@ AddCommandTokeniser::~AddCommandTokeniser(void) {
 	// nothing here
 }
 
+bool AddCommandTokeniser::isValidCommand(std::string userInput) {
+	return isAddCommand(userInput);
+}
+
 bool AddCommandTokeniser::isAddCommand(std::string userInput) {
 	if (isAddActivityCommand(userInput) || isAddTodoCommand(userInput) || isAddFloatingCommand(userInput)) {
 		return true;

--- a/Parser/CommandTokenisers/AddCommandTokeniser.h
+++ b/Parser/CommandTokenisers/AddCommandTokeniser.h
@@ -1,29 +1,24 @@
 #pragma once
 #include "..\CommandTokeniser.h"
 
-// serves two related purposes:
-// first, provides a static public method to check if an entered command is
-// indeed of Add PrimaryCommandType
-// second, tokenises the entered command into the various arguments
 class AddCommandTokeniser : public CommandTokeniser {
 public:
 	AddCommandTokeniser(void);
 	virtual ~AddCommandTokeniser(void);
+
 	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 	virtual bool isValidCommand(std::string userInput) override;
 
 private:
-	// identifiers to determine the exact type of ADD command called
-	static bool isAddFromTo(std::string userInput);
-	static bool isAddBy(std::string userInput);
-	static bool isAddFloating(std::string userInput);
+	bool isAddFromTo(std::string userInput);
+	bool isAddBy(std::string userInput);
+	bool isAddFloating(std::string userInput);
 
-	// tokenisers for the various types of ADD commands
-	void tokeniseAddActivityCommand(std::string userInput);
-	void tokeniseAddTodoCommand(std::string userInput);
-	void tokeniseAddFloatingCommand(std::string userInput);
-	void tokeniseTags(std::string userInput);
+	void tokeniseAddFromTo(std::string userInput);
+	void tokeniseAddBy(std::string userInput);
+	void tokeniseAddFloating(std::string userInput);
 
+	bool isTagged(std::string userInput);
+	void tokeniseTags(std::string userInput);	
 	std::string trimTags(std::string userInput);
-	bool hasTags(std::string userInput);
 };

--- a/Parser/CommandTokenisers/AddCommandTokeniser.h
+++ b/Parser/CommandTokenisers/AddCommandTokeniser.h
@@ -10,14 +10,13 @@ public:
 	AddCommandTokeniser(void);
 	virtual ~AddCommandTokeniser(void);
 	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
-	static bool isAddCommand(std::string userInput);
 	virtual bool isValidCommand(std::string userInput) override;
 
 private:
 	// identifiers to determine the exact type of ADD command called
-	static bool isAddActivityCommand(std::string userInput);
-	static bool isAddTodoCommand(std::string userInput);
-	static bool isAddFloatingCommand(std::string userInput);
+	static bool isAddFromTo(std::string userInput);
+	static bool isAddBy(std::string userInput);
+	static bool isAddFloating(std::string userInput);
 
 	// tokenisers for the various types of ADD commands
 	void tokeniseAddActivityCommand(std::string userInput);

--- a/Parser/CommandTokenisers/AddCommandTokeniser.h
+++ b/Parser/CommandTokenisers/AddCommandTokeniser.h
@@ -7,8 +7,8 @@ public:
 	AddCommandTokeniser(void);
 	virtual ~AddCommandTokeniser(void);
 
-	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 	virtual bool isValidCommand(std::string userInput) override;
+	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 
 private:
 	bool isAddFromTo(std::string userInput);

--- a/Parser/CommandTokenisers/AddCommandTokeniser.h
+++ b/Parser/CommandTokenisers/AddCommandTokeniser.h
@@ -1,3 +1,4 @@
+//@@ author A0097681N
 #pragma once
 #include "..\CommandTokeniser.h"
 

--- a/Parser/CommandTokenisers/AddCommandTokeniser.h
+++ b/Parser/CommandTokenisers/AddCommandTokeniser.h
@@ -11,6 +11,7 @@ public:
 	virtual ~AddCommandTokeniser(void);
 	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 	static bool isAddCommand(std::string userInput);
+	virtual bool isValidCommand(std::string userInput) override;
 
 private:
 	// identifiers to determine the exact type of ADD command called

--- a/Parser/CommandTokenisers/AddCommandTokeniser.h
+++ b/Parser/CommandTokenisers/AddCommandTokeniser.h
@@ -14,11 +14,11 @@ private:
 	bool isAddBy(std::string userInput);
 	bool isAddFloating(std::string userInput);
 
-	void tokeniseAddFromTo(std::string userInput);
-	void tokeniseAddBy(std::string userInput);
-	void tokeniseAddFloating(std::string userInput);
+	void tokeniseAddFromTo(std::string userInput, CommandTokens* tokenisedCommand);
+	void tokeniseAddBy(std::string userInput, CommandTokens* tokenisedCommand);
+	void tokeniseAddFloating(std::string userInput, CommandTokens* tokenisedCommand);
 
 	bool isTagged(std::string userInput);
-	void tokeniseTags(std::string userInput);	
+	void tokeniseTags(std::string userInput, CommandTokens* tokenisedCommand);	
 	std::string trimTags(std::string userInput);
 };

--- a/Parser/CommandTokenisers/AddCommandTokeniser.h
+++ b/Parser/CommandTokenisers/AddCommandTokeniser.h
@@ -7,7 +7,7 @@ public:
 	AddCommandTokeniser(void);
 	virtual ~AddCommandTokeniser(void);
 
-	virtual bool isValidCommand(std::string userInput) override;
+	virtual bool canTokeniseUserInput(std::string userInput) override;
 	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 
 private:

--- a/Parser/CommandTokenisers/CompleteCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/CompleteCommandTokeniser.cpp
@@ -9,7 +9,7 @@ CompleteCommandTokeniser::~CompleteCommandTokeniser(void) {
 }
 
 CommandTokens CompleteCommandTokeniser::tokeniseUserInput(std::string userInput) {
-	_commandTokens.resetMemberVariables();
+	_commandTokens.reset();
 	_commandTokens.setPrimaryCommand(CommandTokens::PrimaryCommandType::Complete);
 
 	tokeniseCompleteIndexCommand(userInput);

--- a/Parser/CommandTokenisers/CompleteCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/CompleteCommandTokeniser.cpp
@@ -9,31 +9,31 @@ CompleteCommandTokeniser::~CompleteCommandTokeniser(void) {
 	// nothing here
 }
 
-CommandTokens CompleteCommandTokeniser::tokeniseUserInput(std::string userInput) {
-	_commandTokens.reset();
-	_commandTokens.setPrimaryCommand(CommandTokens::PrimaryCommandType::Complete);
-
-	tokeniseCompleteIndexCommand(userInput);
-	return _commandTokens;
-}
-
 bool CompleteCommandTokeniser::isValidCommand(std::string userInput) {
-	return isCompleteCommand(userInput);
-}
-
-bool CompleteCommandTokeniser::isCompleteCommand(std::string userInput) {
-	if (isCompleteIndexCommand(userInput)) {
+	if (isCompleteIndex(userInput)) {
 		return true;
 	}
 	return false;
 }
 
-bool CompleteCommandTokeniser::isCompleteIndexCommand(std::string userInput) {
-	return std::regex_match(userInput, std::regex("complete [0-9]+",
-	                                              std::regex_constants::ECMAScript | std::regex_constants::icase));
+CommandTokens CompleteCommandTokeniser::tokeniseUserInput(std::string userInput) {
+	_commandTokens.reset();
+	_commandTokens.setPrimaryCommand(CommandTokens::PrimaryCommandType::Complete);
+
+	if (isCompleteIndex(userInput)) {
+		tokeniseCompleteIndex(userInput);
+	}
+
+	return _commandTokens;
 }
 
-void CompleteCommandTokeniser::tokeniseCompleteIndexCommand(std::string userInput) {
+bool CompleteCommandTokeniser::isCompleteIndex(std::string userInput) {
+	return std::regex_match(userInput,
+	                        std::regex("complete [0-9]+",
+	                                   std::regex_constants::ECMAScript | std::regex_constants::icase));
+}
+
+void CompleteCommandTokeniser::tokeniseCompleteIndex(std::string userInput) {
 	_commandTokens.setSecondaryCommand(CommandTokens::SecondaryCommandType::Index);
 
 	std::smatch matchResults;

--- a/Parser/CommandTokenisers/CompleteCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/CompleteCommandTokeniser.cpp
@@ -16,6 +16,10 @@ CommandTokens CompleteCommandTokeniser::tokeniseUserInput(std::string userInput)
 	return _commandTokens;
 }
 
+bool CompleteCommandTokeniser::isValidCommand(std::string userInput) {
+	return isCompleteCommand(userInput);
+}
+
 bool CompleteCommandTokeniser::isCompleteCommand(std::string userInput) {
 	if (isCompleteIndexCommand(userInput)) {
 		return true;

--- a/Parser/CommandTokenisers/CompleteCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/CompleteCommandTokeniser.cpp
@@ -9,7 +9,7 @@ CompleteCommandTokeniser::~CompleteCommandTokeniser(void) {
 	// nothing here
 }
 
-bool CompleteCommandTokeniser::isValidCommand(std::string userInput) {
+bool CompleteCommandTokeniser::canTokeniseUserInput(std::string userInput) {
 	if (isCompleteIndex(userInput)) {
 		return true;
 	}
@@ -17,7 +17,7 @@ bool CompleteCommandTokeniser::isValidCommand(std::string userInput) {
 }
 
 CommandTokens CompleteCommandTokeniser::tokeniseUserInput(std::string userInput) {
-	assert(isValidCommand(userInput));
+	assert(canTokeniseUserInput(userInput));
 
 	CommandTokens tokenisedCommand(CommandTokens::PrimaryCommandType::Complete);
 

--- a/Parser/CommandTokenisers/CompleteCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/CompleteCommandTokeniser.cpp
@@ -1,3 +1,4 @@
+//@@ author A0097681N
 #include "CompleteCommandTokeniser.h"
 
 CompleteCommandTokeniser::CompleteCommandTokeniser(void) {

--- a/Parser/CommandTokenisers/CompleteCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/CompleteCommandTokeniser.cpp
@@ -17,30 +17,31 @@ bool CompleteCommandTokeniser::isValidCommand(std::string userInput) {
 }
 
 CommandTokens CompleteCommandTokeniser::tokeniseUserInput(std::string userInput) {
-	_commandTokens.reset();
-	_commandTokens.setPrimaryCommand(CommandTokens::PrimaryCommandType::Complete);
+	assert(isValidCommand(userInput));
+
+	CommandTokens tokenisedCommand(CommandTokens::PrimaryCommandType::Complete);
 
 	if (isCompleteIndex(userInput)) {
-		tokeniseCompleteIndex(userInput);
+		tokeniseCompleteIndex(userInput, &tokenisedCommand);
 	}
 
-	return _commandTokens;
+	return tokenisedCommand;
 }
 
 bool CompleteCommandTokeniser::isCompleteIndex(std::string userInput) {
 	return std::regex_match(userInput,
-	                        std::regex("complete [0-9]+",
+	                        std::regex("COMPLETE [0-9]+",
 	                                   std::regex_constants::ECMAScript | std::regex_constants::icase));
 }
 
-void CompleteCommandTokeniser::tokeniseCompleteIndex(std::string userInput) {
-	_commandTokens.setSecondaryCommand(CommandTokens::SecondaryCommandType::Index);
+void CompleteCommandTokeniser::tokeniseCompleteIndex(std::string userInput, CommandTokens* outputCommandTokens) {
+	outputCommandTokens->setSecondaryCommand(CommandTokens::SecondaryCommandType::Index);
 
 	std::smatch matchResults;
 	std::regex_match(userInput, matchResults,
-	                 std::regex("complete ([0-9]+)",
+	                 std::regex("COMPLETE ([0-9]+)",
 	                            std::regex_constants::ECMAScript | std::regex_constants::icase));
 
 	int index = std::stoi(matchResults[1]);
-	_commandTokens.setIndex(index);
+	outputCommandTokens->setIndex(index);
 }

--- a/Parser/CommandTokenisers/CompleteCommandTokeniser.h
+++ b/Parser/CommandTokenisers/CompleteCommandTokeniser.h
@@ -11,6 +11,7 @@ public:
 	virtual ~CompleteCommandTokeniser(void);
 	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 	static bool isCompleteCommand(std::string userInput);
+	virtual bool isValidCommand(std::string userInput) override;
 
 private:
 	// identifiers to determine the exact type of COMPLETE command called,

--- a/Parser/CommandTokenisers/CompleteCommandTokeniser.h
+++ b/Parser/CommandTokenisers/CompleteCommandTokeniser.h
@@ -11,7 +11,6 @@ public:
 	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 
 private:
-	static bool isCompleteIndex(std::string userInput);
-
-	void tokeniseCompleteIndex(std::string userInput);
+	bool isCompleteIndex(std::string userInput);
+	void tokeniseCompleteIndex(std::string userInput, CommandTokens* outputCommandTokens);
 };

--- a/Parser/CommandTokenisers/CompleteCommandTokeniser.h
+++ b/Parser/CommandTokenisers/CompleteCommandTokeniser.h
@@ -1,3 +1,4 @@
+//@@ author A0097681N
 #pragma once
 #include "..\CommandTokeniser.h"
 

--- a/Parser/CommandTokenisers/CompleteCommandTokeniser.h
+++ b/Parser/CommandTokenisers/CompleteCommandTokeniser.h
@@ -7,7 +7,7 @@ public:
 	CompleteCommandTokeniser(void);
 	virtual ~CompleteCommandTokeniser(void);
 
-	virtual bool isValidCommand(std::string userInput) override;
+	virtual bool canTokeniseUserInput(std::string userInput) override;
 	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 
 private:

--- a/Parser/CommandTokenisers/CompleteCommandTokeniser.h
+++ b/Parser/CommandTokenisers/CompleteCommandTokeniser.h
@@ -2,23 +2,16 @@
 #pragma once
 #include "..\CommandTokeniser.h"
 
-// serves two related purposes:
-// first, provides a static public method to check if an entered command is
-// indeed of Complete PrimaryCommandType
-// second, tokenises the entered command into the various arguments
 class CompleteCommandTokeniser : public CommandTokeniser {
 public:
 	CompleteCommandTokeniser(void);
 	virtual ~CompleteCommandTokeniser(void);
-	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
-	static bool isCompleteCommand(std::string userInput);
+
 	virtual bool isValidCommand(std::string userInput) override;
+	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 
 private:
-	// identifiers to determine the exact type of COMPLETE command called,
-	// currently only one type
-	static bool isCompleteIndexCommand(std::string userInput);
+	static bool isCompleteIndex(std::string userInput);
 
-	// tokenisers for the various types of COMPLETE commands
-	void tokeniseCompleteIndexCommand(std::string userInput);
+	void tokeniseCompleteIndex(std::string userInput);
 };

--- a/Parser/CommandTokenisers/ConfigureCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/ConfigureCommandTokeniser.cpp
@@ -8,6 +8,10 @@ ConfigureCommandTokeniser::~ConfigureCommandTokeniser(void) {
 	// nothing here
 }
 
+bool ConfigureCommandTokeniser::isValidCommand(std::string userInput) {
+	return isConfigureCommand(userInput);
+}
+
 bool ConfigureCommandTokeniser::isConfigureCommand(std::string userInput) {
 	if (isConfigureSaveLocation(userInput)) {
 		return true;

--- a/Parser/CommandTokenisers/ConfigureCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/ConfigureCommandTokeniser.cpp
@@ -1,3 +1,4 @@
+//@@ author A0097681N
 #include "ConfigureCommandTokeniser.h"
 
 ConfigureCommandTokeniser::ConfigureCommandTokeniser(void) {

--- a/Parser/CommandTokenisers/ConfigureCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/ConfigureCommandTokeniser.cpp
@@ -9,7 +9,7 @@ ConfigureCommandTokeniser::~ConfigureCommandTokeniser(void) {
 	// nothing here
 }
 
-bool ConfigureCommandTokeniser::isValidCommand(std::string userInput) {
+bool ConfigureCommandTokeniser::canTokeniseUserInput(std::string userInput) {
 	if (isConfigureSaveLocation(userInput)) {
 		return true;
 	}
@@ -17,7 +17,7 @@ bool ConfigureCommandTokeniser::isValidCommand(std::string userInput) {
 }
 
 CommandTokens ConfigureCommandTokeniser::tokeniseUserInput(std::string userInput) {
-	assert(isValidCommand(userInput));
+	assert(canTokeniseUserInput(userInput));
 
 	CommandTokens tokenisedCommand(CommandTokens::PrimaryCommandType::Configure);
 

--- a/Parser/CommandTokenisers/ConfigureCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/ConfigureCommandTokeniser.cpp
@@ -36,6 +36,8 @@ bool ConfigureCommandTokeniser::isConfigureSaveLocation(std::string userInput) {
 }
 
 void ConfigureCommandTokeniser::tokeniseConfigureSaveLocation(std::string userInput) {
+	_commandTokens.setSecondaryCommand(CommandTokens::SecondaryCommandType::SaveLocation);
+
 	std::smatch matchResults;
 
 	std::regex_match(userInput,

--- a/Parser/CommandTokenisers/ConfigureCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/ConfigureCommandTokeniser.cpp
@@ -10,10 +10,6 @@ ConfigureCommandTokeniser::~ConfigureCommandTokeniser(void) {
 }
 
 bool ConfigureCommandTokeniser::isValidCommand(std::string userInput) {
-	return isConfigureCommand(userInput);
-}
-
-bool ConfigureCommandTokeniser::isConfigureCommand(std::string userInput) {
 	if (isConfigureSaveLocation(userInput)) {
 		return true;
 	}
@@ -21,13 +17,15 @@ bool ConfigureCommandTokeniser::isConfigureCommand(std::string userInput) {
 }
 
 CommandTokens ConfigureCommandTokeniser::tokeniseUserInput(std::string userInput) {
-	_commandTokens.setPrimaryCommand(CommandTokens::PrimaryCommandType::Configure);
+	assert(isValidCommand(userInput));
+
+	CommandTokens tokenisedCommand(CommandTokens::PrimaryCommandType::Configure);
 
 	if (isConfigureSaveLocation(userInput)) {
-		tokeniseConfigureSaveLocation(userInput);
+		tokeniseConfigureSaveLocation(userInput, &tokenisedCommand);
 	}
 
-	return _commandTokens;
+	return tokenisedCommand;
 }
 
 bool ConfigureCommandTokeniser::isConfigureSaveLocation(std::string userInput) {
@@ -36,15 +34,14 @@ bool ConfigureCommandTokeniser::isConfigureSaveLocation(std::string userInput) {
 	                                   std::regex_constants::ECMAScript | std::regex_constants::icase));
 }
 
-void ConfigureCommandTokeniser::tokeniseConfigureSaveLocation(std::string userInput) {
-	_commandTokens.setSecondaryCommand(CommandTokens::SecondaryCommandType::SaveLocation);
+void ConfigureCommandTokeniser::tokeniseConfigureSaveLocation(std::string userInput, CommandTokens* outputCommandTokens) {
+	outputCommandTokens->setSecondaryCommand(CommandTokens::SecondaryCommandType::SaveLocation);
 
 	std::smatch matchResults;
-
 	std::regex_match(userInput,
 	                 std::regex("Configure Save Location ([^ ]+)",
 	                            std::regex_constants::ECMAScript | std::regex_constants::icase));
 
 	std::string saveLocation = matchResults[1];
-	_commandTokens.setOtherCommandParameter(saveLocation);
+	outputCommandTokens->setOtherCommandParameter(saveLocation);
 }

--- a/Parser/CommandTokenisers/ConfigureCommandTokeniser.h
+++ b/Parser/CommandTokenisers/ConfigureCommandTokeniser.h
@@ -2,23 +2,15 @@
 #pragma once
 #include "..\CommandTokeniser.h"
 
-// serves two related purposes:
-// first, provides a static public method to check if an entered command is
-// indeed of Configure PrimaryCommandType
-// second, tokenises the entered command into the various arguments
-
 class ConfigureCommandTokeniser : public CommandTokeniser {
 public:
 	ConfigureCommandTokeniser(void);
-	virtual ~ConfigureCommandTokeniser(void);	
-	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
-	static bool isConfigureCommand(std::string userInput);
+	virtual ~ConfigureCommandTokeniser(void);
+
 	virtual bool isValidCommand(std::string userInput) override;
+	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 
 private:
-	// identifiers to determine the exact type of ADD command called
-	static bool isConfigureSaveLocation(std::string userInput);
-
-	// tokenisers for the various types of ADD commands
-	void tokeniseConfigureSaveLocation(std::string userInput);
+	bool isConfigureSaveLocation(std::string userInput);
+	void tokeniseConfigureSaveLocation(std::string userInput, CommandTokens* outputCommandTokens);
 };

--- a/Parser/CommandTokenisers/ConfigureCommandTokeniser.h
+++ b/Parser/CommandTokenisers/ConfigureCommandTokeniser.h
@@ -1,3 +1,4 @@
+//@@ author A0097681N
 #pragma once
 #include "..\CommandTokeniser.h"
 

--- a/Parser/CommandTokenisers/ConfigureCommandTokeniser.h
+++ b/Parser/CommandTokenisers/ConfigureCommandTokeniser.h
@@ -12,6 +12,7 @@ public:
 	virtual ~ConfigureCommandTokeniser(void);	
 	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 	static bool isConfigureCommand(std::string userInput);
+	virtual bool isValidCommand(std::string userInput) override;
 
 private:
 	// identifiers to determine the exact type of ADD command called

--- a/Parser/CommandTokenisers/ConfigureCommandTokeniser.h
+++ b/Parser/CommandTokenisers/ConfigureCommandTokeniser.h
@@ -7,7 +7,7 @@ public:
 	ConfigureCommandTokeniser(void);
 	virtual ~ConfigureCommandTokeniser(void);
 
-	virtual bool isValidCommand(std::string userInput) override;
+	virtual bool canTokeniseUserInput(std::string userInput) override;
 	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 
 private:

--- a/Parser/CommandTokenisers/DeleteCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/DeleteCommandTokeniser.cpp
@@ -9,7 +9,7 @@ DeleteCommandTokeniser::~DeleteCommandTokeniser(void) {
 }
 
 CommandTokens DeleteCommandTokeniser::tokeniseUserInput(::std::string userInput) {
-	_commandTokens.resetMemberVariables();
+	_commandTokens.reset();
 	_commandTokens.setPrimaryCommand(CommandTokens::PrimaryCommandType::Delete);
 
 	if (isDeleteAll(userInput)) {

--- a/Parser/CommandTokenisers/DeleteCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/DeleteCommandTokeniser.cpp
@@ -29,6 +29,10 @@ CommandTokens DeleteCommandTokeniser::tokeniseUserInput(::std::string userInput)
 	return _commandTokens;
 }
 
+bool DeleteCommandTokeniser::isValidCommand(std::string userInput) {
+	return isDeleteCommand(userInput);
+}
+
 bool DeleteCommandTokeniser::isDeleteCommand(std::string userInput) {
 	if (isDeleteAll(userInput) ||
 		isDeleteCompleted(userInput) ||

--- a/Parser/CommandTokenisers/DeleteCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/DeleteCommandTokeniser.cpp
@@ -9,7 +9,7 @@ DeleteCommandTokeniser::~DeleteCommandTokeniser(void) {
 	// nothing here
 }
 
-bool DeleteCommandTokeniser::isValidCommand(std::string userInput) {
+bool DeleteCommandTokeniser::canTokeniseUserInput(std::string userInput) {
 	if (isDeleteAll(userInput) ||
 		isDeleteCompleted(userInput) ||
 		isDeleteIndex(userInput) ||
@@ -22,7 +22,7 @@ bool DeleteCommandTokeniser::isValidCommand(std::string userInput) {
 }
 
 CommandTokens DeleteCommandTokeniser::tokeniseUserInput(::std::string userInput) {
-	assert(isValidCommand(userInput));
+	assert(canTokeniseUserInput(userInput));
 
 	CommandTokens tokenisedCommand(CommandTokens::PrimaryCommandType::Delete);
 

--- a/Parser/CommandTokenisers/DeleteCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/DeleteCommandTokeniser.cpp
@@ -9,133 +9,131 @@ DeleteCommandTokeniser::~DeleteCommandTokeniser(void) {
 	// nothing here
 }
 
-CommandTokens DeleteCommandTokeniser::tokeniseUserInput(::std::string userInput) {
-	_commandTokens.reset();
-	_commandTokens.setPrimaryCommand(CommandTokens::PrimaryCommandType::Delete);
-
-	if (isDeleteAll(userInput)) {
-		tokeniseDeleteAllCommand();
-	} else if (isDeleteCompleted(userInput)) {
-		tokeniseDeleteCompleted(userInput);
-	} else if (isDeleteIndex(userInput)) {
-		tokeniseDeleteIndex(userInput);
-	} else if (isDeleteBy(userInput)) {
-		tokeniseDeleteByCommand(userInput);
-	} else if (isDeleteFromTo(userInput)) {
-		tokeniseDeleteFromToCommand(userInput);
-	} else if (isDeleteFrom(userInput)) {
-		tokeniseDeleteFromCommand(userInput);
-	}
-
-	return _commandTokens;
-}
-
 bool DeleteCommandTokeniser::isValidCommand(std::string userInput) {
-	return isDeleteCommand(userInput);
-}
-
-bool DeleteCommandTokeniser::isDeleteCommand(std::string userInput) {
 	if (isDeleteAll(userInput) ||
 		isDeleteCompleted(userInput) ||
 		isDeleteIndex(userInput) ||
-		isDeleteBy(userInput) ||
 		isDeleteFromTo(userInput) ||
-		isDeleteFrom(userInput)) {
+		isDeleteFrom(userInput) ||
+		isDeleteBy(userInput)) {
 		return true;
 	}
 	return false;
 }
 
-// returns true if userInput contains "delete all", followed by whitespaces;
-// case-insensitive
+CommandTokens DeleteCommandTokeniser::tokeniseUserInput(::std::string userInput) {
+	assert(isValidCommand(userInput));
+
+	CommandTokens tokenisedCommand(CommandTokens::PrimaryCommandType::Delete);
+
+	if (isDeleteAll(userInput)) {
+		tokeniseDeleteAll(&tokenisedCommand);
+	} else if (isDeleteCompleted(userInput)) {
+		tokeniseDeleteCompleted(userInput, &tokenisedCommand);
+	} else if (isDeleteIndex(userInput)) {
+		tokeniseDeleteIndex(userInput, &tokenisedCommand);
+	} else if (isDeleteFromTo(userInput)) {
+		tokeniseDeleteFromTo(userInput, &tokenisedCommand);
+	} else if (isDeleteFrom(userInput)) {
+		tokeniseDeleteFrom(userInput, &tokenisedCommand);
+	} else if (isDeleteBy(userInput)) {
+		tokeniseDeleteBy(userInput, &tokenisedCommand);
+	}
+
+	return tokenisedCommand;
+}
+
 bool DeleteCommandTokeniser::isDeleteAll(std::string userInput) {
 	return std::regex_match(userInput,
-	                        std::regex("delete all",
+	                        std::regex("DELETE ALL",
 	                                   std::regex_constants::ECMAScript | std::regex_constants::icase));
 }
 
 bool DeleteCommandTokeniser::isDeleteCompleted(std::string userInput) {
 	return std::regex_match(userInput,
-	                        std::regex("delete completed",
+	                        std::regex("DELETE COMPLETED",
 	                                   std::regex_constants::ECMAScript | std::regex_constants::icase));
 }
 
 bool DeleteCommandTokeniser::isDeleteIndex(std::string userInput) {
 	return std::regex_match(userInput,
-	                        std::regex("delete [0-9]+",
+	                        std::regex("DELETE [0-9]+",
 	                                   std::regex_constants::ECMAScript | std::regex_constants::icase));
 }
 
-bool DeleteCommandTokeniser::isDeleteBy(std::string userInput) {
-	return std::regex_match(userInput,
-	                        std::regex("delete by .+",
-	                                   std::regex_constants::ECMAScript | std::regex_constants::icase));
-}
-
-// returns true if userInput contains "from" and subsequently "to";
-// case-insensitive
 bool DeleteCommandTokeniser::isDeleteFromTo(std::string userInput) {
 	return std::regex_match(userInput,
-	                        std::regex("delete from .+ to .+",
+	                        std::regex("DELETE FROM .+ TO .+",
 	                                   std::regex_constants::ECMAScript | std::regex_constants::icase));
 }
 
 bool DeleteCommandTokeniser::isDeleteFrom(std::string userInput) {
 	return std::regex_match(userInput,
-	                        std::regex("delete from .+",
+	                        std::regex("DELETE FROM .+",
 	                                   std::regex_constants::ECMAScript | std::regex_constants::icase));
 }
 
-void DeleteCommandTokeniser::tokeniseDeleteAllCommand() {
-	_commandTokens.setSecondaryCommand(CommandTokens::SecondaryCommandType::All);
+bool DeleteCommandTokeniser::isDeleteBy(std::string userInput) {
+	return std::regex_match(userInput,
+	                        std::regex("DELETE BY .+",
+	                                   std::regex_constants::ECMAScript | std::regex_constants::icase));
 }
 
-void DeleteCommandTokeniser::tokeniseDeleteCompleted(std::string userInput) {
-	_commandTokens.setSecondaryCommand(CommandTokens::SecondaryCommandType::Completed);
+void DeleteCommandTokeniser::tokeniseDeleteAll(CommandTokens* outputCommandTokens) {
+	outputCommandTokens->setSecondaryCommand(CommandTokens::SecondaryCommandType::All);
 }
 
-void DeleteCommandTokeniser::tokeniseDeleteIndex(std::string userInput) {
-	_commandTokens.setSecondaryCommand(CommandTokens::SecondaryCommandType::Index);
+void DeleteCommandTokeniser::tokeniseDeleteCompleted(std::string userInput, CommandTokens* outputCommandTokens) {
+	outputCommandTokens->setSecondaryCommand(CommandTokens::SecondaryCommandType::Completed);
+}
+
+void DeleteCommandTokeniser::tokeniseDeleteIndex(std::string userInput, CommandTokens* outputCommandTokens) {
+	outputCommandTokens->setSecondaryCommand(CommandTokens::SecondaryCommandType::Index);
 
 	std::smatch matchResults;
 	std::regex_match(userInput, matchResults,
-	                 std::regex("delete ([0-9]+)",
+	                 std::regex("DELETE ([0-9]+)",
 	                            std::regex_constants::ECMAScript | std::regex_constants::icase));
 
 	int index = stoi(matchResults[1]);
-	_commandTokens.setIndex(index);
+	outputCommandTokens->setIndex(index);
 }
 
-void DeleteCommandTokeniser::tokeniseDeleteByCommand(std::string userInput) {
-	_commandTokens.setSecondaryCommand(CommandTokens::SecondaryCommandType::Todo);
+void DeleteCommandTokeniser::tokeniseDeleteFromTo(std::string userInput, CommandTokens* outputCommandTokens) {
+	outputCommandTokens->setSecondaryCommand(CommandTokens::SecondaryCommandType::Timed);
 
 	std::smatch matchResults;
 	std::regex_match(userInput, matchResults,
-	                 std::regex("delete by (.+)",
+	                 std::regex("DELETE FROM (.+) TO (.+)",
 	                            std::regex_constants::ECMAScript | std::regex_constants::icase));
 
-	_commandTokens.setEndDateTime(parseUserInputDate(matchResults[1]));
+	boost::posix_time::ptime startDateTime = parseUserInputDate(matchResults[1]);
+	boost::posix_time::ptime endDateTime = parseUserInputDate(matchResults[2]);
+
+	outputCommandTokens->setStartDateTime(startDateTime);
+	outputCommandTokens->setEndDateTime(endDateTime);
 }
 
-void DeleteCommandTokeniser::tokeniseDeleteFromToCommand(std::string userInput) {
-	_commandTokens.setSecondaryCommand(CommandTokens::SecondaryCommandType::Timed);
+void DeleteCommandTokeniser::tokeniseDeleteFrom(std::string userInput, CommandTokens* outputCommandTokens) {
+	outputCommandTokens->setSecondaryCommand(CommandTokens::SecondaryCommandType::Start);
 
 	std::smatch matchResults;
 	std::regex_match(userInput, matchResults,
-	                 std::regex("delete from (.+) to (.+)",
+	                 std::regex("DELETE FROM (.+)",
 	                            std::regex_constants::ECMAScript | std::regex_constants::icase));
 
-	_commandTokens.setStartDateTime(parseUserInputDate(matchResults[1]));
-	_commandTokens.setEndDateTime(parseUserInputDate(matchResults[2]));
+	boost::posix_time::ptime startDateTime = parseUserInputDate(matchResults[1]);
+	outputCommandTokens->setStartDateTime(startDateTime);
 }
 
-void DeleteCommandTokeniser::tokeniseDeleteFromCommand(std::string userInput) {
-	_commandTokens.setSecondaryCommand(CommandTokens::SecondaryCommandType::Start);
+void DeleteCommandTokeniser::tokeniseDeleteBy(std::string userInput, CommandTokens* outputCommandTokens) {
+	outputCommandTokens->setSecondaryCommand(CommandTokens::SecondaryCommandType::Todo);
 
 	std::smatch matchResults;
 	std::regex_match(userInput, matchResults,
-	                 std::regex("delete from (.+)",
+	                 std::regex("DELETE BY (.+)",
 	                            std::regex_constants::ECMAScript | std::regex_constants::icase));
 
-	_commandTokens.setStartDateTime(parseUserInputDate(matchResults[1]));
+	boost::posix_time::ptime endDateTime = parseUserInputDate(matchResults[1]);
+	outputCommandTokens->setEndDateTime(endDateTime);
 }

--- a/Parser/CommandTokenisers/DeleteCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/DeleteCommandTokeniser.cpp
@@ -1,3 +1,4 @@
+//@@ author A0097681N
 #include "DeleteCommandTokeniser.h"
 
 DeleteCommandTokeniser::DeleteCommandTokeniser(void) {

--- a/Parser/CommandTokenisers/DeleteCommandTokeniser.h
+++ b/Parser/CommandTokenisers/DeleteCommandTokeniser.h
@@ -11,6 +11,7 @@ public:
 	virtual ~DeleteCommandTokeniser(void);
 	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 	static bool isDeleteCommand(std::string userInput);
+	virtual bool isValidCommand(std::string userInput) override;
 
 private:
 	// identifiers to determine the exact type of DELETE command called

--- a/Parser/CommandTokenisers/DeleteCommandTokeniser.h
+++ b/Parser/CommandTokenisers/DeleteCommandTokeniser.h
@@ -1,3 +1,4 @@
+//@@ author A0097681N
 #pragma once
 #include "..\CommandTokeniser.h"
 

--- a/Parser/CommandTokenisers/DeleteCommandTokeniser.h
+++ b/Parser/CommandTokenisers/DeleteCommandTokeniser.h
@@ -7,7 +7,7 @@ public:
 	DeleteCommandTokeniser(void);
 	virtual ~DeleteCommandTokeniser(void);
 
-	virtual bool isValidCommand(std::string userInput) override;
+	virtual bool canTokeniseUserInput(std::string userInput) override;
 	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 
 private:

--- a/Parser/CommandTokenisers/DeleteCommandTokeniser.h
+++ b/Parser/CommandTokenisers/DeleteCommandTokeniser.h
@@ -2,32 +2,26 @@
 #pragma once
 #include "..\CommandTokeniser.h"
 
-// serves two related purposes:
-// first, provides a static public method to check if an entered command is
-// indeed of Delete PrimaryCommandType
-// second, tokenises the entered command into the various arguments
 class DeleteCommandTokeniser : public CommandTokeniser {
 public:
 	DeleteCommandTokeniser(void);
 	virtual ~DeleteCommandTokeniser(void);
-	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
-	static bool isDeleteCommand(std::string userInput);
+
 	virtual bool isValidCommand(std::string userInput) override;
+	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 
 private:
-	// identifiers to determine the exact type of DELETE command called
-	static bool isDeleteAll(std::string userInput);
-	static bool isDeleteCompleted(std::string userInput);
-	static bool isDeleteIndex(std::string userInput);
-	static bool isDeleteBy(std::string userInput);
-	static bool isDeleteFromTo(std::string userInput);
-	static bool isDeleteFrom(std::string userInput);
+	bool isDeleteAll(std::string userInput);
+	bool isDeleteCompleted(std::string userInput);
+	bool isDeleteIndex(std::string userInput);
+	bool isDeleteBy(std::string userInput);
+	bool isDeleteFromTo(std::string userInput);
+	bool isDeleteFrom(std::string userInput);
 
-	// tokenisers for the various types of DELETE commands
-	void tokeniseDeleteAllCommand(void);
-	void tokeniseDeleteCompleted(std::string userInput);
-	void tokeniseDeleteIndex(std::string userInput);
-	void tokeniseDeleteByCommand(std::string userInput);
-	void tokeniseDeleteFromToCommand(std::string userInput);
-	void tokeniseDeleteFromCommand(std::string userInput);
+	void tokeniseDeleteAll(CommandTokens* outputCommandTokens);
+	void tokeniseDeleteCompleted(std::string userInput, CommandTokens* outputCommandTokens);
+	void tokeniseDeleteIndex(std::string userInput, CommandTokens* outputCommandTokens);
+	void tokeniseDeleteBy(std::string userInput, CommandTokens* outputCommandTokens);
+	void tokeniseDeleteFromTo(std::string userInput, CommandTokens* outputCommandTokens);
+	void tokeniseDeleteFrom(std::string userInput, CommandTokens* outputCommandTokens);
 };

--- a/Parser/CommandTokenisers/DisplayCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/DisplayCommandTokeniser.cpp
@@ -9,7 +9,7 @@ DisplayCommandTokeniser::~DisplayCommandTokeniser(void) {
 	// nothing here
 }
 
-bool DisplayCommandTokeniser::isValidCommand(std::string userInput) {
+bool DisplayCommandTokeniser::canTokeniseUserInput(std::string userInput) {
 	if (isDisplayAll(userInput) ||
 		isDisplayFloating(userInput) ||
 		isDisplayFromTo(userInput) ||
@@ -21,7 +21,7 @@ bool DisplayCommandTokeniser::isValidCommand(std::string userInput) {
 }
 
 CommandTokens DisplayCommandTokeniser::tokeniseUserInput(std::string userInput) {
-	assert(isValidCommand(userInput));
+	assert(canTokeniseUserInput(userInput));
 
 	CommandTokens tokenisedCommand(CommandTokens::PrimaryCommandType::Display);
 

--- a/Parser/CommandTokenisers/DisplayCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/DisplayCommandTokeniser.cpp
@@ -9,112 +9,110 @@ DisplayCommandTokeniser::~DisplayCommandTokeniser(void) {
 	// nothing here
 }
 
-CommandTokens DisplayCommandTokeniser::tokeniseUserInput(std::string userInput) {
-	_commandTokens.reset();
-	_commandTokens.setPrimaryCommand(CommandTokens::PrimaryCommandType::Display);
-
-	if (isDisplayAll(userInput)) {
-		tokeniseDisplayAllCommand();
-	} else if (isDisplayFromTo(userInput)) {
-		tokeniseDisplayFromToCommand(userInput);
-	} else if (isDisplayFrom(userInput)) {
-		tokeniseDisplayFromCommand(userInput);
-	} else if (isDisplayBy(userInput)) {
-		tokeniseDisplayByCommand(userInput);
-	} else if (isDisplayFloating(userInput)) {
-		tokeniseDisplayFloatingCommand();
-	}
-
-	return _commandTokens;
-}
-
-void DisplayCommandTokeniser::tokeniseDisplayFloatingCommand() {
-	_commandTokens.setSecondaryCommand(CommandTokens::SecondaryCommandType::Floating);
-}
-
-void DisplayCommandTokeniser::tokeniseDisplayByCommand(std::string userInput) {
-	_commandTokens.setSecondaryCommand(CommandTokens::SecondaryCommandType::Todo);
-
-	std::smatch matchResults;
-	std::regex_match(userInput, matchResults,
-	                 std::regex("display by (.+)",
-	                            std::regex_constants::ECMAScript | std::regex_constants::icase));
-
-	_commandTokens.setEndDateTime(parseUserInputDate(matchResults[1]));
-}
-
-void DisplayCommandTokeniser::tokeniseDisplayAllCommand() {
-	_commandTokens.setSecondaryCommand(CommandTokens::SecondaryCommandType::All);
-}
-
-void DisplayCommandTokeniser::tokeniseDisplayFromToCommand(std::string userInput) {
-	_commandTokens.setSecondaryCommand(CommandTokens::SecondaryCommandType::Timed);
-
-	std::smatch matchResults;
-	std::regex_match(userInput, matchResults,
-	                 std::regex("display from (.+) to (.+)",
-	                            std::regex_constants::ECMAScript | std::regex_constants::icase));
-
-	_commandTokens.setStartDateTime(parseUserInputDate(matchResults[1]));
-	_commandTokens.setEndDateTime(parseUserInputDate(matchResults[2]));
-}
-
-void DisplayCommandTokeniser::tokeniseDisplayFromCommand(std::string userInput) {
-	_commandTokens.setSecondaryCommand(CommandTokens::SecondaryCommandType::Start);
-
-	std::smatch matchResults;
-	std::regex_match(userInput, matchResults,
-	                 std::regex("display from (.+)",
-	                            std::regex_constants::ECMAScript | std::regex_constants::icase));
-
-	_commandTokens.setStartDateTime(parseUserInputDate(matchResults[1]));
-}
-
 bool DisplayCommandTokeniser::isValidCommand(std::string userInput) {
-	return isDisplayCommand(userInput);
-}
-
-bool DisplayCommandTokeniser::isDisplayCommand(std::string userInput) {
-	if (isDisplayFloating(userInput) ||
-		isDisplayBy(userInput) ||
-		isDisplayAll(userInput) ||
+	if (isDisplayAll(userInput) ||
+		isDisplayFloating(userInput) ||
 		isDisplayFromTo(userInput) ||
-		isDisplayFrom(userInput)) {
+		isDisplayFrom(userInput) ||
+		isDisplayBy(userInput)) {
 		return true;
 	}
 	return false;
 }
 
-bool DisplayCommandTokeniser::isDisplayFloating(std::string userInput) {
-	return std::regex_match(userInput,
-	                        std::regex("display floating",
-	                                   std::regex_constants::ECMAScript | std::regex_constants::icase));
+CommandTokens DisplayCommandTokeniser::tokeniseUserInput(std::string userInput) {
+	assert(isValidCommand(userInput));
+
+	CommandTokens tokenisedCommand(CommandTokens::PrimaryCommandType::Display);
+
+	if (isDisplayAll(userInput)) {
+		tokeniseDisplayAll(&tokenisedCommand);
+	} else if (isDisplayFloating(userInput)) {
+		tokeniseDisplayFloating(&tokenisedCommand);
+	} else if (isDisplayFromTo(userInput)) {
+		tokeniseDisplayFromTo(userInput, &tokenisedCommand);
+	} else if (isDisplayFrom(userInput)) {
+		tokeniseDisplayFrom(userInput, &tokenisedCommand);
+	} else if (isDisplayBy(userInput)) {
+		tokeniseDisplayBy(userInput, &tokenisedCommand);
+	}
+
+	return tokenisedCommand;
 }
 
-bool DisplayCommandTokeniser::isDisplayBy(std::string userInput) {
-	return std::regex_match(userInput,
-	                        std::regex("display by .+",
-	                                   std::regex_constants::ECMAScript | std::regex_constants::icase));
+void DisplayCommandTokeniser::tokeniseDisplayAll(CommandTokens* outputCommandTokens) {
+	outputCommandTokens->setSecondaryCommand(CommandTokens::SecondaryCommandType::All);
 }
 
-// returns true if userInput contains "display all", followed by whitespaces;
-// case-insensitive
+void DisplayCommandTokeniser::tokeniseDisplayFloating(CommandTokens* outputCommandTokens) {
+	outputCommandTokens->setSecondaryCommand(CommandTokens::SecondaryCommandType::Floating);
+}
+
+void DisplayCommandTokeniser::tokeniseDisplayFromTo(std::string userInput, CommandTokens* outputCommandTokens) {
+	outputCommandTokens->setSecondaryCommand(CommandTokens::SecondaryCommandType::Timed);
+
+	std::smatch matchResults;
+	std::regex_match(userInput, matchResults,
+	                 std::regex("DISPLAY FROM (.+) TO (.+)",
+	                            std::regex_constants::ECMAScript | std::regex_constants::icase));
+
+	boost::posix_time::ptime startDateTime = parseUserInputDate(matchResults[1]);
+	boost::posix_time::ptime endDateTime = parseUserInputDate(matchResults[2]);
+
+	outputCommandTokens->setStartDateTime(startDateTime);
+	outputCommandTokens->setEndDateTime(endDateTime);
+}
+
+void DisplayCommandTokeniser::tokeniseDisplayFrom(std::string userInput, CommandTokens* outputCommandTokens) {
+	outputCommandTokens->setSecondaryCommand(CommandTokens::SecondaryCommandType::Start);
+
+	std::smatch matchResults;
+	std::regex_match(userInput, matchResults,
+	                 std::regex("DISPLAY FROM (.+)",
+	                            std::regex_constants::ECMAScript | std::regex_constants::icase));
+
+	boost::posix_time::ptime startDateTime = parseUserInputDate(matchResults[1]);
+	outputCommandTokens->setStartDateTime(startDateTime);
+}
+
+void DisplayCommandTokeniser::tokeniseDisplayBy(std::string userInput, CommandTokens* outputCommandTokens) {
+	outputCommandTokens->setSecondaryCommand(CommandTokens::SecondaryCommandType::Todo);
+
+	std::smatch matchResults;
+	std::regex_match(userInput, matchResults,
+	                 std::regex("DISPLAY BY (.+)",
+	                            std::regex_constants::ECMAScript | std::regex_constants::icase));
+
+	boost::posix_time::ptime endDateTime = parseUserInputDate(matchResults[1]);
+	outputCommandTokens->setEndDateTime(endDateTime);
+}
+
 bool DisplayCommandTokeniser::isDisplayAll(std::string userInput) {
 	return std::regex_match(userInput,
-	                        std::regex("display all",
+	                        std::regex("DISPLAY ALL",
 	                                   std::regex_constants::ECMAScript | std::regex_constants::icase));
 }
 
-// returns true if userInput contains "from" and subsequently "to";
-// case-insensitive
+bool DisplayCommandTokeniser::isDisplayFloating(std::string userInput) {
+	return std::regex_match(userInput,
+	                        std::regex("DISPLAY FLOATING",
+	                                   std::regex_constants::ECMAScript | std::regex_constants::icase));
+}
+
 bool DisplayCommandTokeniser::isDisplayFromTo(std::string userInput) {
 	return std::regex_match(userInput,
-	                        std::regex("display from .+ to .+",
+	                        std::regex("DISPLAY FROM .+ TO .+",
 	                                   std::regex_constants::ECMAScript | std::regex_constants::icase));
 }
 
 bool DisplayCommandTokeniser::isDisplayFrom(std::string userInput) {
 	return std::regex_match(userInput,
-	                        std::regex("display from .+",
+	                        std::regex("DISPLAY FROM .+",
+	                                   std::regex_constants::ECMAScript | std::regex_constants::icase));
+}
+
+bool DisplayCommandTokeniser::isDisplayBy(std::string userInput) {
+	return std::regex_match(userInput,
+	                        std::regex("DISPLAY BY .+",
 	                                   std::regex_constants::ECMAScript | std::regex_constants::icase));
 }

--- a/Parser/CommandTokenisers/DisplayCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/DisplayCommandTokeniser.cpp
@@ -69,6 +69,10 @@ void DisplayCommandTokeniser::tokeniseDisplayFromCommand(std::string userInput) 
 	_commandTokens.setStartDateTime(parseUserInputDate(matchResults[1]));
 }
 
+bool DisplayCommandTokeniser::isValidCommand(std::string userInput) {
+	return isDisplayCommand(userInput);
+}
+
 bool DisplayCommandTokeniser::isDisplayCommand(std::string userInput) {
 	if (isDisplayFloating(userInput) ||
 		isDisplayBy(userInput) ||

--- a/Parser/CommandTokenisers/DisplayCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/DisplayCommandTokeniser.cpp
@@ -1,3 +1,4 @@
+//@@ author A0097681N
 #include "DisplayCommandTokeniser.h"
 
 DisplayCommandTokeniser::DisplayCommandTokeniser(void) {

--- a/Parser/CommandTokenisers/DisplayCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/DisplayCommandTokeniser.cpp
@@ -9,7 +9,7 @@ DisplayCommandTokeniser::~DisplayCommandTokeniser(void) {
 }
 
 CommandTokens DisplayCommandTokeniser::tokeniseUserInput(std::string userInput) {
-	_commandTokens.resetMemberVariables();
+	_commandTokens.reset();
 	_commandTokens.setPrimaryCommand(CommandTokens::PrimaryCommandType::Display);
 
 	if (isDisplayAll(userInput)) {

--- a/Parser/CommandTokenisers/DisplayCommandTokeniser.h
+++ b/Parser/CommandTokenisers/DisplayCommandTokeniser.h
@@ -7,7 +7,7 @@ public:
 	DisplayCommandTokeniser(void);
 	virtual ~DisplayCommandTokeniser(void);
 
-	virtual bool isValidCommand(std::string userInput) override;
+	virtual bool canTokeniseUserInput(std::string userInput) override;
 	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 
 private:

--- a/Parser/CommandTokenisers/DisplayCommandTokeniser.h
+++ b/Parser/CommandTokenisers/DisplayCommandTokeniser.h
@@ -11,6 +11,7 @@ public:
 	virtual ~DisplayCommandTokeniser(void);
 	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 	static bool isDisplayCommand(std::string userInput);
+	virtual bool isValidCommand(std::string userInput) override;
 
 private:
 	// identifiers to determine the exact type of DISPLAY command called

--- a/Parser/CommandTokenisers/DisplayCommandTokeniser.h
+++ b/Parser/CommandTokenisers/DisplayCommandTokeniser.h
@@ -2,30 +2,24 @@
 #pragma once
 #include "..\CommandTokeniser.h"
 
-// serves two related purposes:
-// first, provides a static public method to check if an entered command is
-// indeed of Display PrimaryCommandType
-// second, tokenises the entered command into the various arguments
 class DisplayCommandTokeniser : public CommandTokeniser {
 public:
 	DisplayCommandTokeniser(void);
 	virtual ~DisplayCommandTokeniser(void);
-	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
-	static bool isDisplayCommand(std::string userInput);
+
 	virtual bool isValidCommand(std::string userInput) override;
+	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 
 private:
-	// identifiers to determine the exact type of DISPLAY command called
-	static bool isDisplayAll(std::string userInput);
-	static bool isDisplayFromTo(std::string userInput);
-	static bool isDisplayFrom(std::string userInput);
-	static bool isDisplayBy(std::string userInput);
-	static bool isDisplayFloating(std::string userInput);
+	bool isDisplayAll(std::string userInput);
+	bool isDisplayFloating(std::string userInput);
+	bool isDisplayFromTo(std::string userInput);
+	bool isDisplayFrom(std::string userInput);
+	bool isDisplayBy(std::string userInput);
 
-	// tokenisers for the various types of DISPLAY commands
-	void tokeniseDisplayAllCommand(void);
-	void tokeniseDisplayFromToCommand(std::string userInput);
-	void tokeniseDisplayFromCommand(std::string userInput);
-	void tokeniseDisplayByCommand(std::string userInput);
-	void tokeniseDisplayFloatingCommand();
+	void tokeniseDisplayAll(CommandTokens* outputCommandTokens);
+	void tokeniseDisplayFloating(CommandTokens* outputCommandTokens);
+	void tokeniseDisplayFromTo(std::string userInput, CommandTokens* outputCommandTokens);
+	void tokeniseDisplayFrom(std::string userInput, CommandTokens* outputCommandTokens);
+	void tokeniseDisplayBy(std::string userInput, CommandTokens* outputCommandTokens);
 };

--- a/Parser/CommandTokenisers/DisplayCommandTokeniser.h
+++ b/Parser/CommandTokenisers/DisplayCommandTokeniser.h
@@ -1,3 +1,4 @@
+//@@ author A0097681N
 #pragma once
 #include "..\CommandTokeniser.h"
 

--- a/Parser/CommandTokenisers/EditCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/EditCommandTokeniser.cpp
@@ -9,7 +9,7 @@ EditCommandTokeniser::~EditCommandTokeniser(void) {
 	// nothing here
 }
 
-bool EditCommandTokeniser::isValidCommand(std::string userInput) {
+bool EditCommandTokeniser::canTokeniseUserInput(std::string userInput) {
 	if (isEditName(userInput) ||
 		isEditEndDate(userInput) ||
 		isEditStartDate(userInput)) {
@@ -19,7 +19,7 @@ bool EditCommandTokeniser::isValidCommand(std::string userInput) {
 }
 
 CommandTokens EditCommandTokeniser::tokeniseUserInput(std::string userInput) {
-	assert(isValidCommand(userInput));
+	assert(canTokeniseUserInput(userInput));
 
 	CommandTokens tokenisedCommand(CommandTokens::PrimaryCommandType::Edit);
 

--- a/Parser/CommandTokenisers/EditCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/EditCommandTokeniser.cpp
@@ -23,6 +23,10 @@ CommandTokens EditCommandTokeniser::tokeniseUserInput(std::string userInput) {
 	return _commandTokens;
 }
 
+bool EditCommandTokeniser::isValidCommand(std::string userInput) {
+	return isEditCommand(userInput);
+}
+
 bool EditCommandTokeniser::isEditCommand(std::string userInput) {
 	if (isEditEndDate(userInput) ||
 		isEditStartDate(userInput) ||

--- a/Parser/CommandTokenisers/EditCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/EditCommandTokeniser.cpp
@@ -9,92 +9,90 @@ EditCommandTokeniser::~EditCommandTokeniser(void) {
 	// nothing here
 }
 
-CommandTokens EditCommandTokeniser::tokeniseUserInput(std::string userInput) {
-	_commandTokens.reset();
-	_commandTokens.setPrimaryCommand(CommandTokens::PrimaryCommandType::Edit);
-
-	if (isEditName(userInput)) {
-		tokeniseEditNameCommand(userInput);
-	} else if (isEditStartDate(userInput)) {
-		tokeniseEditStartDateCommand(userInput);
-	} else if (isEditEndDate(userInput)) {
-		tokeniseEditEndDateCommand(userInput);
-	}
-
-	return _commandTokens;
-}
-
 bool EditCommandTokeniser::isValidCommand(std::string userInput) {
-	return isEditCommand(userInput);
-}
-
-bool EditCommandTokeniser::isEditCommand(std::string userInput) {
-	if (isEditEndDate(userInput) ||
-		isEditStartDate(userInput) ||
-		isEditName(userInput)) {
+	if (isEditName(userInput) ||
+		isEditEndDate(userInput) ||
+		isEditStartDate(userInput)) {
 		return true;
 	}
 	return false;
 }
 
-bool EditCommandTokeniser::isEditEndDate(std::string userInput) {
+CommandTokens EditCommandTokeniser::tokeniseUserInput(std::string userInput) {
+	assert(isValidCommand(userInput));
+
+	CommandTokens tokenisedCommand(CommandTokens::PrimaryCommandType::Edit);
+
+	if (isEditName(userInput)) {
+		tokeniseEditName(userInput, &tokenisedCommand);
+	} else if (isEditStartDate(userInput)) {
+		tokeniseEditStartDate(userInput, &tokenisedCommand);
+	} else if (isEditEndDate(userInput)) {
+		tokeniseEditEndDate(userInput, &tokenisedCommand);
+	}
+
+	return tokenisedCommand;
+}
+
+bool EditCommandTokeniser::isEditName(std::string userInput) {
 	return std::regex_match(userInput,
-	                        std::regex("edit end [0-9]+ .+",
+	                        std::regex("EDIT NAME [0-9]+ .+",
 	                                   std::regex_constants::ECMAScript | std::regex_constants::icase));
 }
 
 bool EditCommandTokeniser::isEditStartDate(std::string userInput) {
 	return std::regex_match(userInput,
-	                        std::regex("edit start [0-9]+ .+",
+	                        std::regex("EDIT START [0-9]+ .+",
 	                                   std::regex_constants::ECMAScript | std::regex_constants::icase));
 }
 
-bool EditCommandTokeniser::isEditName(std::string userInput) {
+bool EditCommandTokeniser::isEditEndDate(std::string userInput) {
 	return std::regex_match(userInput,
-	                        std::regex("edit name [0-9]+ .+",
+	                        std::regex("EDIT END [0-9]+ .+",
 	                                   std::regex_constants::ECMAScript | std::regex_constants::icase));
 }
 
-void EditCommandTokeniser::tokeniseEditEndDateCommand(std::string userInput) {
-	_commandTokens.setSecondaryCommand(CommandTokens::SecondaryCommandType::End);
+void EditCommandTokeniser::tokeniseEditName(std::string userInput, CommandTokens* outputCommandTokens) {
+	outputCommandTokens->setSecondaryCommand(CommandTokens::SecondaryCommandType::Name);
 
 	std::smatch matchResults;
 	std::regex_match(userInput, matchResults,
-	                 std::regex("edit end ([0-9]+) (.*)",
+	                 std::regex("EDIT NAME ([0-9]+) (.+)",
 	                            std::regex_constants::ECMAScript | std::regex_constants::icase));
 
 	int index = stoi(matchResults[1]);
-	_commandTokens.setIndex(index);
+	std::string taskName = matchResults[2];
 
-	boost::posix_time::ptime endDate = parseUserInputDate(matchResults[2]);
-	_commandTokens.setEndDateTime(endDate);
+	outputCommandTokens->setIndex(index);
+	outputCommandTokens->setTaskName(taskName);
 }
 
-void EditCommandTokeniser::tokeniseEditStartDateCommand(std::string userInput) {
-	_commandTokens.setSecondaryCommand(CommandTokens::SecondaryCommandType::Start);
+void EditCommandTokeniser::tokeniseEditStartDate(std::string userInput, CommandTokens* outputCommandTokens) {
+	outputCommandTokens->setSecondaryCommand(CommandTokens::SecondaryCommandType::Start);
 
 	std::smatch matchResults;
 	std::regex_match(userInput, matchResults,
-	                 std::regex("edit start ([0-9]+) (.*)",
+	                 std::regex("EDIT START ([0-9]+) (.+)",
 	                            std::regex_constants::ECMAScript | std::regex_constants::icase));
 
 	int index = stoi(matchResults[1]);
-	_commandTokens.setIndex(index);
-
 	boost::posix_time::ptime startDate = parseUserInputDate(matchResults[2]);
-	_commandTokens.setStartDateTime(startDate);
+
+	outputCommandTokens->setIndex(index);
+	outputCommandTokens->setStartDateTime(startDate);
 }
 
-void EditCommandTokeniser::tokeniseEditNameCommand(std::string userInput) {
-	_commandTokens.setSecondaryCommand(CommandTokens::SecondaryCommandType::Name);
+void EditCommandTokeniser::tokeniseEditEndDate(std::string userInput, CommandTokens* outputCommandTokens) {
+	outputCommandTokens->setSecondaryCommand(CommandTokens::SecondaryCommandType::End);
 
 	std::smatch matchResults;
 	std::regex_match(userInput, matchResults,
-	                 std::regex("edit name ([0-9]+) (.*)",
+	                 std::regex("EDIT END ([0-9]+) (.+)",
 	                            std::regex_constants::ECMAScript | std::regex_constants::icase));
 
 	int index = stoi(matchResults[1]);
-	_commandTokens.setIndex(index);
+	boost::posix_time::ptime endDate = parseUserInputDate(matchResults[2]);
 
-	_commandTokens.setTaskName(matchResults[2]);
+	outputCommandTokens->setIndex(index);
+	outputCommandTokens->setEndDateTime(endDate);
 }

--- a/Parser/CommandTokenisers/EditCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/EditCommandTokeniser.cpp
@@ -9,7 +9,7 @@ EditCommandTokeniser::~EditCommandTokeniser(void) {
 }
 
 CommandTokens EditCommandTokeniser::tokeniseUserInput(std::string userInput) {
-	_commandTokens.resetMemberVariables();
+	_commandTokens.reset();
 	_commandTokens.setPrimaryCommand(CommandTokens::PrimaryCommandType::Edit);
 
 	if (isEditName(userInput)) {

--- a/Parser/CommandTokenisers/EditCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/EditCommandTokeniser.cpp
@@ -1,3 +1,4 @@
+//@@ author A0097681N
 #include "EditCommandTokeniser.h"
 
 EditCommandTokeniser::EditCommandTokeniser(void) {

--- a/Parser/CommandTokenisers/EditCommandTokeniser.h
+++ b/Parser/CommandTokenisers/EditCommandTokeniser.h
@@ -1,3 +1,4 @@
+//@@ author A0097681N
 #pragma once
 #include "..\CommandTokeniser.h"
 

--- a/Parser/CommandTokenisers/EditCommandTokeniser.h
+++ b/Parser/CommandTokenisers/EditCommandTokeniser.h
@@ -2,26 +2,20 @@
 #pragma once
 #include "..\CommandTokeniser.h"
 
-// serves two related purposes:
-// first, provides a static public method to check if an entered command is
-// indeed of Edit PrimaryCommandType
-// second, tokenises the entered command into the various arguments
 class EditCommandTokeniser : public CommandTokeniser {
 public:
 	EditCommandTokeniser(void);
 	virtual ~EditCommandTokeniser(void);
-	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
-	static bool isEditCommand(std::string userInput);
+
 	virtual bool isValidCommand(std::string userInput) override;
+	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 
 private:
-	// identifiers to determine the exact type of EDIT command called
-	static bool isEditName(std::string userInput);
-	static bool isEditStartDate(std::string userInput);
-	static bool isEditEndDate(std::string userInput);
+	bool isEditName(std::string userInput);
+	bool isEditStartDate(std::string userInput);
+	bool isEditEndDate(std::string userInput);
 
-	// tokenisers for the various types of EDIT commands
-	void tokeniseEditNameCommand(std::string userInput);
-	void tokeniseEditStartDateCommand(std::string userInput);
-	void tokeniseEditEndDateCommand(std::string userInput);
+	void tokeniseEditName(std::string userInput, CommandTokens* outputCommandTokens);
+	void tokeniseEditStartDate(std::string userInput, CommandTokens* outputCommandTokens);
+	void tokeniseEditEndDate(std::string userInput, CommandTokens* outputCommandTokens);
 };

--- a/Parser/CommandTokenisers/EditCommandTokeniser.h
+++ b/Parser/CommandTokenisers/EditCommandTokeniser.h
@@ -7,7 +7,7 @@ public:
 	EditCommandTokeniser(void);
 	virtual ~EditCommandTokeniser(void);
 
-	virtual bool isValidCommand(std::string userInput) override;
+	virtual bool canTokeniseUserInput(std::string userInput) override;
 	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 
 private:

--- a/Parser/CommandTokenisers/EditCommandTokeniser.h
+++ b/Parser/CommandTokenisers/EditCommandTokeniser.h
@@ -11,6 +11,7 @@ public:
 	virtual ~EditCommandTokeniser(void);
 	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 	static bool isEditCommand(std::string userInput);
+	virtual bool isValidCommand(std::string userInput) override;
 
 private:
 	// identifiers to determine the exact type of EDIT command called

--- a/Parser/CommandTokenisers/ExportCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/ExportCommandTokeniser.cpp
@@ -9,7 +9,7 @@ ExportCommandTokeniser::~ExportCommandTokeniser(void) {
 	// nothing here
 }
 
-bool ExportCommandTokeniser::isValidCommand(std::string userInput) {
+bool ExportCommandTokeniser::canTokeniseUserInput(std::string userInput) {
 	if (isExportToLocalDisk(userInput)) {
 		return true;
 	}
@@ -17,7 +17,7 @@ bool ExportCommandTokeniser::isValidCommand(std::string userInput) {
 }
 
 CommandTokens ExportCommandTokeniser::tokeniseUserInput(std::string userInput) {
-	assert(isValidCommand(userInput));
+	assert(canTokeniseUserInput(userInput));
 
 	CommandTokens tokenisedCommand(CommandTokens::PrimaryCommandType::Export);
 

--- a/Parser/CommandTokenisers/ExportCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/ExportCommandTokeniser.cpp
@@ -9,40 +9,38 @@ ExportCommandTokeniser::~ExportCommandTokeniser(void) {
 	// nothing here
 }
 
-CommandTokens ExportCommandTokeniser::tokeniseUserInput(std::string userInput) {
-	_commandTokens.setPrimaryCommand(CommandTokens::PrimaryCommandType::Export);
-
-	if (isExportToLocalDiskCommand(userInput)) {
-		tokeniseExportToLocalDiskCommand(userInput);
-	}
-
-	return _commandTokens;
-}
-
 bool ExportCommandTokeniser::isValidCommand(std::string userInput) {
-	return isExportCommand(userInput);
-}
-
-bool ExportCommandTokeniser::isExportCommand(std::string userInput) {
-	if (isExportToLocalDiskCommand(userInput)) {
+	if (isExportToLocalDisk(userInput)) {
 		return true;
 	}
 	return false;
 }
 
-bool ExportCommandTokeniser::isExportToLocalDiskCommand(std::string userInput) {
-	return std::regex_match(userInput, std::regex("export [^ ]+",
+CommandTokens ExportCommandTokeniser::tokeniseUserInput(std::string userInput) {
+	assert(isValidCommand(userInput));
+
+	CommandTokens tokenisedCommand(CommandTokens::PrimaryCommandType::Export);
+
+	if (isExportToLocalDisk(userInput)) {
+		tokeniseExportToLocalDisk(userInput, &tokenisedCommand);
+	}
+
+	return tokenisedCommand;
+}
+
+bool ExportCommandTokeniser::isExportToLocalDisk(std::string userInput) {
+	return std::regex_match(userInput, std::regex("EXPORT [^ ]+",
 	                                              std::regex_constants::ECMAScript | std::regex_constants::icase));
 }
 
-void ExportCommandTokeniser::tokeniseExportToLocalDiskCommand(std::string userInput) {
-	_commandTokens.setSecondaryCommand(CommandTokens::SecondaryCommandType::None);
+void ExportCommandTokeniser::tokeniseExportToLocalDisk(std::string userInput, CommandTokens* outputCommandTokens) {
+	outputCommandTokens->setSecondaryCommand(CommandTokens::SecondaryCommandType::None);
 
 	std::smatch matchResults;
 	std::regex_match(userInput, matchResults,
-	                 std::regex("export ([^ ]+)",
+	                 std::regex("EXPORT ([^ ]+)",
 	                            std::regex_constants::ECMAScript | std::regex_constants::icase));
 
 	std::string exportPath = matchResults[1];
-	_commandTokens.setOtherCommandParameter(exportPath);
+	outputCommandTokens->setOtherCommandParameter(exportPath);
 }

--- a/Parser/CommandTokenisers/ExportCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/ExportCommandTokeniser.cpp
@@ -1,5 +1,5 @@
+//@@ author A0097681N
 #include "ExportCommandTokeniser.h"
-
 
 ExportCommandTokeniser::ExportCommandTokeniser(void) {
 	// nothing here

--- a/Parser/CommandTokenisers/ExportCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/ExportCommandTokeniser.cpp
@@ -19,6 +19,10 @@ CommandTokens ExportCommandTokeniser::tokeniseUserInput(std::string userInput) {
 	return _commandTokens;
 }
 
+bool ExportCommandTokeniser::isValidCommand(std::string userInput) {
+	return isExportCommand(userInput);
+}
+
 bool ExportCommandTokeniser::isExportCommand(std::string userInput) {
 	if (isExportToLocalDiskCommand(userInput)) {
 		return true;

--- a/Parser/CommandTokenisers/ExportCommandTokeniser.h
+++ b/Parser/CommandTokenisers/ExportCommandTokeniser.h
@@ -7,7 +7,7 @@ public:
 	ExportCommandTokeniser(void);
 	virtual ~ExportCommandTokeniser(void);
 
-	virtual bool isValidCommand(std::string userInput) override;
+	virtual bool canTokeniseUserInput(std::string userInput) override;
 	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 
 private:

--- a/Parser/CommandTokenisers/ExportCommandTokeniser.h
+++ b/Parser/CommandTokenisers/ExportCommandTokeniser.h
@@ -2,23 +2,15 @@
 #pragma once
 #include "..\CommandTokeniser.h"
 
-// serves two related purposes:
-// first, provides a static public method to check if an entered command is
-// indeed of Export PrimaryCommandType
-// second, tokenises the entered command into the various arguments
 class ExportCommandTokeniser : public CommandTokeniser {
 public:
 	ExportCommandTokeniser(void);
 	virtual ~ExportCommandTokeniser(void);
-	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
-	static bool isExportCommand(std::string userInput);
+
 	virtual bool isValidCommand(std::string userInput) override;
+	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 
 private:
-	// identifiers to determine the exact type of EXPORT command called,
-	// currently only one type
-	static bool isExportToLocalDiskCommand(std::string userInput);
-
-	// tokenisers for the various types of EXPORT commands
-	void tokeniseExportToLocalDiskCommand(std::string userInput);
+	bool isExportToLocalDisk(std::string userInput);
+	void tokeniseExportToLocalDisk(std::string userInput, CommandTokens* outputCommandTokens);
 };

--- a/Parser/CommandTokenisers/ExportCommandTokeniser.h
+++ b/Parser/CommandTokenisers/ExportCommandTokeniser.h
@@ -1,3 +1,4 @@
+//@@ author A0097681N
 #pragma once
 #include "..\CommandTokeniser.h"
 

--- a/Parser/CommandTokenisers/ExportCommandTokeniser.h
+++ b/Parser/CommandTokenisers/ExportCommandTokeniser.h
@@ -11,6 +11,7 @@ public:
 	virtual ~ExportCommandTokeniser(void);
 	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 	static bool isExportCommand(std::string userInput);
+	virtual bool isValidCommand(std::string userInput) override;
 
 private:
 	// identifiers to determine the exact type of EXPORT command called,

--- a/Parser/CommandTokenisers/ImportCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/ImportCommandTokeniser.cpp
@@ -8,40 +8,40 @@ ImportCommandTokeniser::~ImportCommandTokeniser(void) {
 	// nothing
 }
 
-CommandTokens ImportCommandTokeniser::tokeniseUserInput(std::string userInput) {
-	_commandTokens.setPrimaryCommand(CommandTokens::PrimaryCommandType::Import);
-
-	if (isImportLocalCommand(userInput)) {
-		tokeniseImportLocalCommand(userInput);
-	}
-
-	return _commandTokens;
-}
-
 bool ImportCommandTokeniser::isValidCommand(std::string userInput) {
-	return isImportCommand(userInput);
-}
-
-bool ImportCommandTokeniser::isImportCommand(std::string userInput) {
-	if (isImportLocalCommand(userInput)) {
+	if (isImportLocal(userInput)) {
 		return true;
 	}
 	return false;
 }
 
-bool ImportCommandTokeniser::isImportLocalCommand(std::string userInput) {
-	return std::regex_match(userInput,
-	                        std::regex("Import [^ ]+", std::regex_constants::ECMAScript | std::regex_constants::icase));
+CommandTokens ImportCommandTokeniser::tokeniseUserInput(std::string userInput) {
+	assert(isValidCommand(userInput));
+
+	CommandTokens tokenisedCommand(CommandTokens::PrimaryCommandType::Import);
+
+	if (isImportLocal(userInput)) {
+		tokeniseImportLocal(userInput, &tokenisedCommand);
+	}
+
+	return tokenisedCommand;
 }
 
-void ImportCommandTokeniser::tokeniseImportLocalCommand(std::string userInput) {
-	_commandTokens.setSecondaryCommand(CommandTokens::SecondaryCommandType::None);
+bool ImportCommandTokeniser::isImportLocal(std::string userInput) {
+	return std::regex_match(userInput,
+	                        std::regex("IMPORT [^ ]+",
+	                                   std::regex_constants::ECMAScript | std::regex_constants::icase));
+}
+
+void ImportCommandTokeniser::tokeniseImportLocal(std::string userInput, CommandTokens* outputCommandTokens) {
+	outputCommandTokens->setSecondaryCommand(CommandTokens::SecondaryCommandType::None);
 
 	std::smatch matchResults;
 	std::regex_match(userInput,
 	                 matchResults,
-	                 std::regex("import ([^ ]+)", std::regex_constants::ECMAScript | std::regex_constants::icase));
+	                 std::regex("IMPORT ([^ ]+)",
+	                            std::regex_constants::ECMAScript | std::regex_constants::icase));
 
 	std::string importFilePath = matchResults[1];
-	_commandTokens.setOtherCommandParameter(importFilePath);
+	outputCommandTokens->setOtherCommandParameter(importFilePath);
 }

--- a/Parser/CommandTokenisers/ImportCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/ImportCommandTokeniser.cpp
@@ -8,7 +8,7 @@ ImportCommandTokeniser::~ImportCommandTokeniser(void) {
 	// nothing
 }
 
-bool ImportCommandTokeniser::isValidCommand(std::string userInput) {
+bool ImportCommandTokeniser::canTokeniseUserInput(std::string userInput) {
 	if (isImportLocal(userInput)) {
 		return true;
 	}
@@ -16,7 +16,7 @@ bool ImportCommandTokeniser::isValidCommand(std::string userInput) {
 }
 
 CommandTokens ImportCommandTokeniser::tokeniseUserInput(std::string userInput) {
-	assert(isValidCommand(userInput));
+	assert(canTokeniseUserInput(userInput));
 
 	CommandTokens tokenisedCommand(CommandTokens::PrimaryCommandType::Import);
 

--- a/Parser/CommandTokenisers/ImportCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/ImportCommandTokeniser.cpp
@@ -18,6 +18,10 @@ CommandTokens ImportCommandTokeniser::tokeniseUserInput(std::string userInput) {
 	return _commandTokens;
 }
 
+bool ImportCommandTokeniser::isValidCommand(std::string userInput) {
+	return isImportCommand(userInput);
+}
+
 bool ImportCommandTokeniser::isImportCommand(std::string userInput) {
 	if (isImportLocalCommand(userInput)) {
 		return true;

--- a/Parser/CommandTokenisers/ImportCommandTokeniser.h
+++ b/Parser/CommandTokenisers/ImportCommandTokeniser.h
@@ -11,6 +11,7 @@ public:
 	virtual ~ImportCommandTokeniser(void);
 	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 	static bool isImportCommand(std::string userInput);
+	virtual bool isValidCommand(std::string userInput) override;
 
 private:
 	// identifiers to determine the exact type of IMPORT command called

--- a/Parser/CommandTokenisers/ImportCommandTokeniser.h
+++ b/Parser/CommandTokenisers/ImportCommandTokeniser.h
@@ -1,3 +1,4 @@
+//@@ author A0097681N
 #pragma once
 #include "..\CommandTokeniser.h"
 

--- a/Parser/CommandTokenisers/ImportCommandTokeniser.h
+++ b/Parser/CommandTokenisers/ImportCommandTokeniser.h
@@ -2,22 +2,15 @@
 #pragma once
 #include "..\CommandTokeniser.h"
 
-// serves two related purposes:
-// first, provides a static public method to check if an entered command is
-// indeed of Import PrimaryCommandType
-// second, tokenises the entered command into the various arguments
 class ImportCommandTokeniser : public CommandTokeniser {
 public:
 	ImportCommandTokeniser(void);
 	virtual ~ImportCommandTokeniser(void);
-	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
-	static bool isImportCommand(std::string userInput);
+
 	virtual bool isValidCommand(std::string userInput) override;
+	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 
 private:
-	// identifiers to determine the exact type of IMPORT command called
-	static bool isImportLocalCommand(std::string userInput);
-
-	// tokenisers for the various types of IMPORT commands
-	void tokeniseImportLocalCommand(std::string userInput);
+	bool isImportLocal(std::string userInput);
+	void tokeniseImportLocal(std::string userInput, CommandTokens* outputCommandTokens);
 };

--- a/Parser/CommandTokenisers/ImportCommandTokeniser.h
+++ b/Parser/CommandTokenisers/ImportCommandTokeniser.h
@@ -7,7 +7,7 @@ public:
 	ImportCommandTokeniser(void);
 	virtual ~ImportCommandTokeniser(void);
 
-	virtual bool isValidCommand(std::string userInput) override;
+	virtual bool canTokeniseUserInput(std::string userInput) override;
 	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 
 private:

--- a/Parser/CommandTokenisers/RefreshCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/RefreshCommandTokeniser.cpp
@@ -19,6 +19,10 @@ CommandTokens RefreshCommandTokeniser::tokeniseUserInput(std::string userInput) 
 	return _commandTokens;
 }
 
+bool RefreshCommandTokeniser::isValidCommand(std::string userInput) {
+	return isRefreshCommand(userInput);
+}
+
 bool RefreshCommandTokeniser::isRefreshCommand(std::string userInput) {
 	if (isRefreshSimpliciterCommand(userInput)) {
 		return true;

--- a/Parser/CommandTokenisers/RefreshCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/RefreshCommandTokeniser.cpp
@@ -9,7 +9,7 @@ RefreshCommandTokeniser::~RefreshCommandTokeniser(void) {
 	// nothing
 }
 
-bool RefreshCommandTokeniser::isValidCommand(std::string userInput) {
+bool RefreshCommandTokeniser::canTokeniseUserInput(std::string userInput) {
 	if (isRefreshBasic(userInput)) {
 		return true;
 	}
@@ -17,7 +17,7 @@ bool RefreshCommandTokeniser::isValidCommand(std::string userInput) {
 }
 
 CommandTokens RefreshCommandTokeniser::tokeniseUserInput(std::string userInput) {
-	assert(isValidCommand(userInput));
+	assert(canTokeniseUserInput(userInput));
 
 	CommandTokens tokenisedCommand(CommandTokens::PrimaryCommandType::Refresh);
 

--- a/Parser/CommandTokenisers/RefreshCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/RefreshCommandTokeniser.cpp
@@ -1,5 +1,5 @@
+//@@ author A0097681N
 #include "RefreshCommandTokeniser.h"
-
 
 RefreshCommandTokeniser::RefreshCommandTokeniser(void) {
 	// nothing

--- a/Parser/CommandTokenisers/RefreshCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/RefreshCommandTokeniser.cpp
@@ -9,33 +9,31 @@ RefreshCommandTokeniser::~RefreshCommandTokeniser(void) {
 	// nothing
 }
 
-CommandTokens RefreshCommandTokeniser::tokeniseUserInput(std::string userInput) {
-	_commandTokens.setPrimaryCommand(CommandTokens::PrimaryCommandType::Refresh);
-
-	if (isRefreshSimpliciterCommand(userInput)) {
-		tokeniseRefreshSimpliciterCommand(userInput);
-	}
-
-	return _commandTokens;
-}
-
 bool RefreshCommandTokeniser::isValidCommand(std::string userInput) {
-	return isRefreshCommand(userInput);
-}
-
-bool RefreshCommandTokeniser::isRefreshCommand(std::string userInput) {
-	if (isRefreshSimpliciterCommand(userInput)) {
+	if (isRefreshBasic(userInput)) {
 		return true;
 	}
 	return false;
 }
 
-bool RefreshCommandTokeniser::isRefreshSimpliciterCommand(std::string userInput) {
+CommandTokens RefreshCommandTokeniser::tokeniseUserInput(std::string userInput) {
+	assert(isValidCommand(userInput));
+
+	CommandTokens tokenisedCommand(CommandTokens::PrimaryCommandType::Refresh);
+
+	if (isRefreshBasic(userInput)) {
+		tokeniseRefreshBasic(userInput, &tokenisedCommand);
+	}
+
+	return tokenisedCommand;
+}
+
+bool RefreshCommandTokeniser::isRefreshBasic(std::string userInput) {
 	return std::regex_match(userInput,
-	                        std::regex("refresh",
+	                        std::regex("REFRESH",
 	                                   std::regex_constants::ECMAScript | std::regex_constants::icase));
 }
 
-void RefreshCommandTokeniser::tokeniseRefreshSimpliciterCommand(std::string userInput) {
-	_commandTokens.setSecondaryCommand(CommandTokens::SecondaryCommandType::None);
+void RefreshCommandTokeniser::tokeniseRefreshBasic(std::string userInput, CommandTokens* outputCommandTokens) {
+	outputCommandTokens->setSecondaryCommand(CommandTokens::SecondaryCommandType::None);
 }

--- a/Parser/CommandTokenisers/RefreshCommandTokeniser.h
+++ b/Parser/CommandTokenisers/RefreshCommandTokeniser.h
@@ -2,23 +2,15 @@
 #pragma once
 #include "..\CommandTokeniser.h"
 
-// serves two related purposes:
-// first, provides a static public method to check if an entered command is
-// indeed of Refresh PrimaryCommandType
-// second, tokenises the entered command into the various arguments
-
 class RefreshCommandTokeniser : public CommandTokeniser {
 public:
 	RefreshCommandTokeniser(void);
 	virtual ~RefreshCommandTokeniser(void);
-	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
-	static bool isRefreshCommand(std::string userInput);
+
 	virtual bool isValidCommand(std::string userInput) override;
+	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 
 private:
-	// identifiers to determine the exact type of REFRESH command called
-	static bool isRefreshSimpliciterCommand(std::string userInput);
-
-	// tokenisers for the various types of REFRESH commands
-	void tokeniseRefreshSimpliciterCommand(std::string userInput);
+	bool isRefreshBasic(std::string userInput);
+	void tokeniseRefreshBasic(std::string userInput, CommandTokens* outputCommandTokens);
 };

--- a/Parser/CommandTokenisers/RefreshCommandTokeniser.h
+++ b/Parser/CommandTokenisers/RefreshCommandTokeniser.h
@@ -7,7 +7,7 @@ public:
 	RefreshCommandTokeniser(void);
 	virtual ~RefreshCommandTokeniser(void);
 
-	virtual bool isValidCommand(std::string userInput) override;
+	virtual bool canTokeniseUserInput(std::string userInput) override;
 	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 
 private:

--- a/Parser/CommandTokenisers/RefreshCommandTokeniser.h
+++ b/Parser/CommandTokenisers/RefreshCommandTokeniser.h
@@ -1,3 +1,4 @@
+//@@ author A0097681N
 #pragma once
 #include "..\CommandTokeniser.h"
 

--- a/Parser/CommandTokenisers/RefreshCommandTokeniser.h
+++ b/Parser/CommandTokenisers/RefreshCommandTokeniser.h
@@ -12,6 +12,7 @@ public:
 	virtual ~RefreshCommandTokeniser(void);
 	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 	static bool isRefreshCommand(std::string userInput);
+	virtual bool isValidCommand(std::string userInput) override;
 
 private:
 	// identifiers to determine the exact type of REFRESH command called

--- a/Parser/CommandTokenisers/SearchCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/SearchCommandTokeniser.cpp
@@ -1,3 +1,4 @@
+//@@ author A0097681N
 #include "SearchCommandTokeniser.h"
 
 SearchCommandTokeniser::SearchCommandTokeniser(void) {

--- a/Parser/CommandTokenisers/SearchCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/SearchCommandTokeniser.cpp
@@ -9,7 +9,7 @@ SearchCommandTokeniser::~SearchCommandTokeniser(void) {
 	// nothing
 }
 
-bool SearchCommandTokeniser::isValidCommand(std::string userInput) {
+bool SearchCommandTokeniser::canTokeniseUserInput(std::string userInput) {
 	if (isSearchName(userInput) ||
 		isSearchStartBefore(userInput) ||
 		isSearchStartAfter(userInput) ||
@@ -22,7 +22,7 @@ bool SearchCommandTokeniser::isValidCommand(std::string userInput) {
 }
 
 CommandTokens SearchCommandTokeniser::tokeniseUserInput(std::string userInput) {
-	assert(isValidCommand(userInput));
+	assert(canTokeniseUserInput(userInput));
 
 	CommandTokens tokenisedCommand(CommandTokens::PrimaryCommandType::Search);
 

--- a/Parser/CommandTokenisers/SearchCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/SearchCommandTokeniser.cpp
@@ -28,6 +28,10 @@ CommandTokens SearchCommandTokeniser::tokeniseUserInput(std::string userInput) {
 	return _commandTokens;
 }
 
+bool SearchCommandTokeniser::isValidCommand(std::string userInput) {
+	return isSearchCommand(userInput);
+}
+
 bool SearchCommandTokeniser::isSearchCommand(std::string userInput) {
 	if (isSearchNameCommand(userInput) ||
 		isSearchStartBeforeCommand(userInput) ||

--- a/Parser/CommandTokenisers/SearchCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/SearchCommandTokeniser.cpp
@@ -9,153 +9,150 @@ SearchCommandTokeniser::~SearchCommandTokeniser(void) {
 	// nothing
 }
 
-CommandTokens SearchCommandTokeniser::tokeniseUserInput(std::string userInput) {
-	_commandTokens.setPrimaryCommand(CommandTokens::PrimaryCommandType::Search);
-
-	if (isSearchNameCommand(userInput)) {
-		tokeniseSearchNameCommand(userInput);
-	} else if (isSearchStartBeforeCommand(userInput)) {
-		tokeniseSearchStartBeforeCommand(userInput);
-	} else if (isSearchStartAfterCommand(userInput)) {
-		tokeniseSearchStartAfterCommand(userInput);
-	} else if (isSearchEndBeforeCommand(userInput)) {
-		tokeniseSearchEndBeforeCommand(userInput);
-	} else if (isSearchEndAfterCommand(userInput)) {
-		tokeniseSearchEndAfterCommand(userInput);
-	} else if (isSearchTagsCommand(userInput)) {
-		tokeniseSearchTagsCommand(userInput);
-	}
-
-	return _commandTokens;
-}
-
 bool SearchCommandTokeniser::isValidCommand(std::string userInput) {
-	return isSearchCommand(userInput);
-}
-
-bool SearchCommandTokeniser::isSearchCommand(std::string userInput) {
-	if (isSearchNameCommand(userInput) ||
-		isSearchStartBeforeCommand(userInput) ||
-		isSearchStartAfterCommand(userInput) ||
-		isSearchEndBeforeCommand(userInput) ||
-		isSearchEndAfterCommand(userInput) ||
-		isSearchTagsCommand(userInput)) {
+	if (isSearchName(userInput) ||
+		isSearchStartBefore(userInput) ||
+		isSearchStartAfter(userInput) ||
+		isSearchEndBefore(userInput) ||
+		isSearchEndAfter(userInput) ||
+		isSearchTags(userInput)) {
 		return true;
 	}
 	return false;
 }
 
-bool SearchCommandTokeniser::isSearchNameCommand(std::string userInput) {
+CommandTokens SearchCommandTokeniser::tokeniseUserInput(std::string userInput) {
+	assert(isValidCommand(userInput));
+
+	CommandTokens tokenisedCommand(CommandTokens::PrimaryCommandType::Search);
+
+	if (isSearchName(userInput)) {
+		tokeniseSearchName(userInput, &tokenisedCommand);
+	} else if (isSearchStartBefore(userInput)) {
+		tokeniseSearchStartBefore(userInput, &tokenisedCommand);
+	} else if (isSearchStartAfter(userInput)) {
+		tokeniseSearchStartAfter(userInput, &tokenisedCommand);
+	} else if (isSearchEndBefore(userInput)) {
+		tokeniseSearchEndBefore(userInput, &tokenisedCommand);
+	} else if (isSearchEndAfter(userInput)) {
+		tokeniseSearchEndAfter(userInput, &tokenisedCommand);
+	} else if (isSearchTags(userInput)) {
+		tokeniseSearchTags(userInput, &tokenisedCommand);
+	}
+
+	return tokenisedCommand;
+}
+
+bool SearchCommandTokeniser::isSearchName(std::string userInput) {
 	return std::regex_match(userInput,
-	                        std::regex("search name .+",
+	                        std::regex("SEARCH NAME .+",
 	                                   std::regex_constants::ECMAScript | std::regex_constants::icase));
 }
 
-bool SearchCommandTokeniser::isSearchStartBeforeCommand(std::string userInput) {
+bool SearchCommandTokeniser::isSearchStartBefore(std::string userInput) {
 	return std::regex_match(userInput,
-	                        std::regex("search start before .+",
+	                        std::regex("SEARCH START BEFORE .+",
 	                                   std::regex_constants::ECMAScript | std::regex_constants::icase));
 }
 
-bool SearchCommandTokeniser::isSearchStartAfterCommand(std::string userInput) {
+bool SearchCommandTokeniser::isSearchStartAfter(std::string userInput) {
 	return std::regex_match(userInput,
-	                        std::regex("search start after .+",
+	                        std::regex("SEARCH START AFTER .+",
 	                                   std::regex_constants::ECMAScript | std::regex_constants::icase));
 }
 
-bool SearchCommandTokeniser::isSearchEndBeforeCommand(std::string userInput) {
+bool SearchCommandTokeniser::isSearchEndBefore(std::string userInput) {
 	return std::regex_match(userInput,
-	                        std::regex("search end before .+",
+	                        std::regex("SEARCH END BEFORE .+",
 	                                   std::regex_constants::ECMAScript | std::regex_constants::icase));
 }
 
-bool SearchCommandTokeniser::isSearchEndAfterCommand(std::string userInput) {
+bool SearchCommandTokeniser::isSearchEndAfter(std::string userInput) {
 	return std::regex_match(userInput,
-	                        std::regex("search end after .+",
+	                        std::regex("SEARCH END AFTER .+",
 	                                   std::regex_constants::ECMAScript | std::regex_constants::icase));
 }
 
-bool SearchCommandTokeniser::isSearchTagsCommand(std::string userInput) {
+bool SearchCommandTokeniser::isSearchTags(std::string userInput) {
 	return std::regex_match(userInput,
-	                        std::regex("search tags( #[^ ]+)+",
+	                        std::regex("SEARCH TAGS( #[^ ]+)+",
 	                                   std::regex_constants::ECMAScript | std::regex_constants::icase));
 }
 
-void SearchCommandTokeniser::tokeniseSearchNameCommand(std::string userInput) {
-	_commandTokens.setSecondaryCommand(CommandTokens::SecondaryCommandType::Name);
+void SearchCommandTokeniser::tokeniseSearchName(std::string userInput, CommandTokens* outputCommandTokens) {
+	outputCommandTokens->setSecondaryCommand(CommandTokens::SecondaryCommandType::Name);
 
 	std::smatch matchResults;
 	std::regex_match(userInput, matchResults,
-	                 std::regex("search name (.+)",
+	                 std::regex("SEARCH NAME (.+)",
 	                            std::regex_constants::ECMAScript | std::regex_constants::icase));
 
 	std::string taskNameToSearch = matchResults[1];
-	_commandTokens.setTaskName(taskNameToSearch);
+	outputCommandTokens->setTaskName(taskNameToSearch);
 }
 
-void SearchCommandTokeniser::tokeniseSearchStartBeforeCommand(std::string userInput) {
-	_commandTokens.setSecondaryCommand(CommandTokens::SecondaryCommandType::StartBefore);
+void SearchCommandTokeniser::tokeniseSearchStartBefore(std::string userInput, CommandTokens* outputCommandTokens) {
+	outputCommandTokens->setSecondaryCommand(CommandTokens::SecondaryCommandType::StartBefore);
 
 	std::smatch matchResults;
 	std::regex_match(userInput, matchResults,
-	                 std::regex("search start before (.+)",
+	                 std::regex("SEARCH START BEFORE (.+)",
 	                            std::regex_constants::ECMAScript | std::regex_constants::icase));
 
-	_commandTokens.setStartDateTime(parseUserInputDate(matchResults[1]));
+	boost::posix_time::ptime startDateTime = parseUserInputDate(matchResults[1]);
+	outputCommandTokens->setStartDateTime(startDateTime);
 }
 
-void SearchCommandTokeniser::tokeniseSearchStartAfterCommand(std::string userInput) {
-	_commandTokens.setSecondaryCommand(CommandTokens::SecondaryCommandType::StartAfter);
+void SearchCommandTokeniser::tokeniseSearchStartAfter(std::string userInput, CommandTokens* outputCommandTokens) {
+	outputCommandTokens->setSecondaryCommand(CommandTokens::SecondaryCommandType::StartAfter);
 
 	std::smatch matchResults;
 	std::regex_match(userInput, matchResults,
-	                 std::regex("search start after (.+)",
+	                 std::regex("SEARCH START AFTER (.+)",
 	                            std::regex_constants::ECMAScript | std::regex_constants::icase));
 
-	_commandTokens.setStartDateTime(parseUserInputDate(matchResults[1]));
+	boost::posix_time::ptime startDateTime = parseUserInputDate(matchResults[1]);
+	outputCommandTokens->setStartDateTime(startDateTime);
 }
 
-void SearchCommandTokeniser::tokeniseSearchEndBeforeCommand(std::string userInput) {
-	_commandTokens.setSecondaryCommand(CommandTokens::SecondaryCommandType::EndBefore);
+void SearchCommandTokeniser::tokeniseSearchEndBefore(std::string userInput, CommandTokens* outputCommandTokens) {
+	outputCommandTokens->setSecondaryCommand(CommandTokens::SecondaryCommandType::EndBefore);
 
 	std::smatch matchResults;
 	std::regex_match(userInput, matchResults,
-	                 std::regex("search end before (.+)",
+	                 std::regex("SEARCH END BEFORE (.+)",
 	                            std::regex_constants::ECMAScript | std::regex_constants::icase));
 
-	_commandTokens.setEndDateTime(parseUserInputDate(matchResults[1]));
+	boost::posix_time::ptime endDateTime = parseUserInputDate(matchResults[1]);
+	outputCommandTokens->setEndDateTime(endDateTime);
 }
 
-void SearchCommandTokeniser::tokeniseSearchEndAfterCommand(std::string userInput) {
-	_commandTokens.setSecondaryCommand(CommandTokens::SecondaryCommandType::EndAfter);
+void SearchCommandTokeniser::tokeniseSearchEndAfter(std::string userInput, CommandTokens* outputCommandTokens) {
+	outputCommandTokens->setSecondaryCommand(CommandTokens::SecondaryCommandType::EndAfter);
 
 	std::smatch matchResults;
 	std::regex_match(userInput, matchResults,
-	                 std::regex("search end after (.+)",
+	                 std::regex("SEARCH END AFTER (.+)",
 	                            std::regex_constants::ECMAScript | std::regex_constants::icase));
 
-	_commandTokens.setEndDateTime(parseUserInputDate(matchResults[1]));
+	boost::posix_time::ptime endDateTime = parseUserInputDate(matchResults[1]);
+	outputCommandTokens->setEndDateTime(endDateTime);
 }
 
-void SearchCommandTokeniser::tokeniseSearchTagsCommand(std::string userInput) {
-	_commandTokens.setSecondaryCommand(CommandTokens::SecondaryCommandType::Tags);
+void SearchCommandTokeniser::tokeniseSearchTags(std::string userInput, CommandTokens* outputCommandTokens) {
+	outputCommandTokens->setSecondaryCommand(CommandTokens::SecondaryCommandType::Tags);
 
-	tokeniseTags(userInput);
-}
-
-void SearchCommandTokeniser::tokeniseTags(std::string userInput) {
-	std::vector<std::string> newTags;
-
+	std::vector<std::string> tokenisedTags;
 	std::smatch matchResults;
 	while (std::regex_search(userInput, matchResults,
 	                         std::regex(" (#[^ ]+)",
 	                                    std::regex_constants::ECMAScript | std::regex_constants::icase))) {
 
-		newTags.push_back(matchResults[1]);
+		tokenisedTags.push_back(matchResults[1]);
 
 		// continue the search in the right substring
 		userInput = matchResults.suffix().str();
 	}
 
-	_commandTokens.setTags(newTags);
+	outputCommandTokens->setTags(tokenisedTags);
 }

--- a/Parser/CommandTokenisers/SearchCommandTokeniser.h
+++ b/Parser/CommandTokenisers/SearchCommandTokeniser.h
@@ -11,6 +11,7 @@ public:
 	virtual ~SearchCommandTokeniser(void);
 	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 	static bool isSearchCommand(std::string userInput);
+	virtual bool isValidCommand(std::string userInput) override;
 
 private:
 	// identifiers to determine the exact type of SEARCH command called

--- a/Parser/CommandTokenisers/SearchCommandTokeniser.h
+++ b/Parser/CommandTokenisers/SearchCommandTokeniser.h
@@ -1,3 +1,4 @@
+//@@ author A0097681N
 #pragma once
 #include "..\CommandTokeniser.h"
 

--- a/Parser/CommandTokenisers/SearchCommandTokeniser.h
+++ b/Parser/CommandTokenisers/SearchCommandTokeniser.h
@@ -7,7 +7,7 @@ public:
 	SearchCommandTokeniser(void);
 	virtual ~SearchCommandTokeniser(void);
 
-	virtual bool isValidCommand(std::string userInput) override;
+	virtual bool canTokeniseUserInput(std::string userInput) override;
 	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 
 private:

--- a/Parser/CommandTokenisers/SearchCommandTokeniser.h
+++ b/Parser/CommandTokenisers/SearchCommandTokeniser.h
@@ -2,34 +2,26 @@
 #pragma once
 #include "..\CommandTokeniser.h"
 
-// serves two related purposes:
-// first, provides a static public method to check if an entered command is
-// indeed of Search PrimaryCommandType
-// second, tokenises the entered command into the various arguments
 class SearchCommandTokeniser : public CommandTokeniser {
 public:
 	SearchCommandTokeniser(void);
 	virtual ~SearchCommandTokeniser(void);
-	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
-	static bool isSearchCommand(std::string userInput);
+
 	virtual bool isValidCommand(std::string userInput) override;
+	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 
 private:
-	// identifiers to determine the exact type of SEARCH command called
-	static bool isSearchNameCommand(std::string userInput);
-	static bool isSearchStartBeforeCommand(std::string userInput);
-	static bool isSearchStartAfterCommand(std::string userInput);
-	static bool isSearchEndBeforeCommand(std::string userInput);
-	static bool isSearchEndAfterCommand(std::string userInput);
-	static bool isSearchTagsCommand(std::string userInput);
+	static bool isSearchName(std::string userInput);
+	static bool isSearchStartBefore(std::string userInput);
+	static bool isSearchStartAfter(std::string userInput);
+	static bool isSearchEndBefore(std::string userInput);
+	static bool isSearchEndAfter(std::string userInput);
+	static bool isSearchTags(std::string userInput);
 
-	// tokenisers for the various types of SEARCH commands
-	void tokeniseSearchNameCommand(std::string userInput);
-	void tokeniseSearchStartBeforeCommand(std::string userInput);
-	void tokeniseSearchStartAfterCommand(std::string userInput);
-	void tokeniseSearchEndBeforeCommand(std::string userInput);
-	void tokeniseSearchEndAfterCommand(std::string userInput);
-	void tokeniseSearchTagsCommand(std::string userInput);
-
-	void tokeniseTags(std::string userInput);
+	void tokeniseSearchName(std::string userInput, CommandTokens* outputCommandTokens);
+	void tokeniseSearchStartBefore(std::string userInput, CommandTokens* outputCommandTokens);
+	void tokeniseSearchStartAfter(std::string userInput, CommandTokens* outputCommandTokens);
+	void tokeniseSearchEndBefore(std::string userInput, CommandTokens* outputCommandTokens);
+	void tokeniseSearchEndAfter(std::string userInput, CommandTokens* outputCommandTokens);
+	void tokeniseSearchTags(std::string userInput, CommandTokens* outputCommandTokens);
 };

--- a/Parser/CommandTokenisers/TagCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/TagCommandTokeniser.cpp
@@ -9,50 +9,46 @@ TagCommandTokeniser::~TagCommandTokeniser(void) {
 	// nothing here
 }
 
-
-CommandTokens TagCommandTokeniser::tokeniseUserInput(std::string userInput) {
-	_commandTokens.setPrimaryCommand(CommandTokens::PrimaryCommandType::Tag);
-
-	if (isTagIndexCommand(userInput)) {
-		tokeniseTagIndexCommand(userInput);
-	}
-
-	return _commandTokens;
-}
-
 bool TagCommandTokeniser::isValidCommand(std::string userInput) {
-	return isTagCommand(userInput);
-}
-
-bool TagCommandTokeniser::isTagCommand(std::string userInput) {
-	if (isTagIndexCommand(userInput)) {
+	if (isTagIndex(userInput)) {
 		return true;
 	}
-
 	return false;
 }
 
-bool TagCommandTokeniser::isTagIndexCommand(std::string userInput) {
+CommandTokens TagCommandTokeniser::tokeniseUserInput(std::string userInput) {
+	assert(isValidCommand(userInput));
+
+	CommandTokens tokenisedCommand(CommandTokens::PrimaryCommandType::Tag);
+
+	if (isTagIndex(userInput)) {
+		tokeniseTagIndex(userInput, &tokenisedCommand);
+	}
+
+	return tokenisedCommand;
+}
+
+bool TagCommandTokeniser::isTagIndex(std::string userInput) {
 	return std::regex_match(userInput,
-	                        std::regex("tag [0-9]+( (#[^ ]+))+",
+	                        std::regex("TAG [0-9]+( (#[^ ]+))+",
 	                                   std::regex_constants::ECMAScript | std::regex_constants::icase));
 }
 
-void TagCommandTokeniser::tokeniseTagIndexCommand(std::string userInput) {
-	_commandTokens.setSecondaryCommand(CommandTokens::SecondaryCommandType::Index);
+void TagCommandTokeniser::tokeniseTagIndex(std::string userInput, CommandTokens* outputCommandTokens) {
+	outputCommandTokens->setSecondaryCommand(CommandTokens::SecondaryCommandType::Index);
 
 	std::smatch matchResults;
 	std::regex_match(userInput, matchResults,
-	                 std::regex("tag ([0-9]+) .*",
+	                 std::regex("TAG ([0-9]+) .*",
 	                            std::regex_constants::ECMAScript | std::regex_constants::icase));
 
 	int index = stoi(matchResults[1]);
-	_commandTokens.setIndex(index);
+	outputCommandTokens->setIndex(index);
 
-	tokeniseTags(userInput);
+	tokeniseTags(userInput, outputCommandTokens);
 }
 
-void TagCommandTokeniser::tokeniseTags(std::string userInput) {
+void TagCommandTokeniser::tokeniseTags(std::string userInput, CommandTokens* outputCommandTokens) {
 	std::vector<std::string> newTags;
 
 	std::smatch matchResults;
@@ -66,5 +62,5 @@ void TagCommandTokeniser::tokeniseTags(std::string userInput) {
 		userInput = matchResults.suffix().str();
 	}
 
-	_commandTokens.setTags(newTags);
+	outputCommandTokens->setTags(newTags);
 }

--- a/Parser/CommandTokenisers/TagCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/TagCommandTokeniser.cpp
@@ -1,5 +1,5 @@
+//@@ author A0097681N
 #include "TagCommandTokeniser.h"
-
 
 TagCommandTokeniser::TagCommandTokeniser(void) {
 	// nothing here

--- a/Parser/CommandTokenisers/TagCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/TagCommandTokeniser.cpp
@@ -9,7 +9,7 @@ TagCommandTokeniser::~TagCommandTokeniser(void) {
 	// nothing here
 }
 
-bool TagCommandTokeniser::isValidCommand(std::string userInput) {
+bool TagCommandTokeniser::canTokeniseUserInput(std::string userInput) {
 	if (isTagIndex(userInput)) {
 		return true;
 	}
@@ -17,7 +17,7 @@ bool TagCommandTokeniser::isValidCommand(std::string userInput) {
 }
 
 CommandTokens TagCommandTokeniser::tokeniseUserInput(std::string userInput) {
-	assert(isValidCommand(userInput));
+	assert(canTokeniseUserInput(userInput));
 
 	CommandTokens tokenisedCommand(CommandTokens::PrimaryCommandType::Tag);
 

--- a/Parser/CommandTokenisers/TagCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/TagCommandTokeniser.cpp
@@ -20,6 +20,10 @@ CommandTokens TagCommandTokeniser::tokeniseUserInput(std::string userInput) {
 	return _commandTokens;
 }
 
+bool TagCommandTokeniser::isValidCommand(std::string userInput) {
+	return isTagCommand(userInput);
+}
+
 bool TagCommandTokeniser::isTagCommand(std::string userInput) {
 	if (isTagIndexCommand(userInput)) {
 		return true;

--- a/Parser/CommandTokenisers/TagCommandTokeniser.h
+++ b/Parser/CommandTokenisers/TagCommandTokeniser.h
@@ -1,3 +1,4 @@
+//@@ author A0097681N
 #pragma once
 #include "..\CommandTokeniser.h"
 

--- a/Parser/CommandTokenisers/TagCommandTokeniser.h
+++ b/Parser/CommandTokenisers/TagCommandTokeniser.h
@@ -7,7 +7,7 @@ public:
 	TagCommandTokeniser(void);
 	virtual ~TagCommandTokeniser(void);
 
-	virtual bool isValidCommand(std::string userInput) override;
+	virtual bool canTokeniseUserInput(std::string userInput) override;
 	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 
 private:

--- a/Parser/CommandTokenisers/TagCommandTokeniser.h
+++ b/Parser/CommandTokenisers/TagCommandTokeniser.h
@@ -2,24 +2,16 @@
 #pragma once
 #include "..\CommandTokeniser.h"
 
-// serves two related purposes:
-// first, provides a static public method to check if an entered command is
-// indeed of Tag PrimaryCommandType
-// second, tokenises the entered command into the various arguments
 class TagCommandTokeniser : public CommandTokeniser {
 public:
 	TagCommandTokeniser(void);
 	virtual ~TagCommandTokeniser(void);
-	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
-	static bool isTagCommand(std::string userInput);
+
 	virtual bool isValidCommand(std::string userInput) override;
+	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 
 private:
-	// identifiers to determine the exact type of TAG command called
-	static bool isTagIndexCommand(std::string userInput);
-
-	// tokenisers for the various types of TAG commands
-	void tokeniseTagIndexCommand(std::string userInput);
-
-	void tokeniseTags(std::string userInput);
+	bool isTagIndex(std::string userInput);
+	void tokeniseTagIndex(std::string userInput, CommandTokens* outputCommandTokens);
+	void tokeniseTags(std::string userInput, CommandTokens* outputCommandTokens);
 };

--- a/Parser/CommandTokenisers/TagCommandTokeniser.h
+++ b/Parser/CommandTokenisers/TagCommandTokeniser.h
@@ -11,6 +11,7 @@ public:
 	virtual ~TagCommandTokeniser(void);
 	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 	static bool isTagCommand(std::string userInput);
+	virtual bool isValidCommand(std::string userInput) override;
 
 private:
 	// identifiers to determine the exact type of TAG command called

--- a/Parser/CommandTokenisers/UndoCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/UndoCommandTokeniser.cpp
@@ -1,3 +1,4 @@
+//@@ author A0097681N
 #include "UndoCommandTokeniser.h"
 
 UndoCommandTokeniser::UndoCommandTokeniser(void) {

--- a/Parser/CommandTokenisers/UndoCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/UndoCommandTokeniser.cpp
@@ -9,7 +9,7 @@ UndoCommandTokeniser::~UndoCommandTokeniser(void) {
 	// nothing here
 }
 
-bool UndoCommandTokeniser::isValidCommand(std::string userInput) {
+bool UndoCommandTokeniser::canTokeniseUserInput(std::string userInput) {
 	if (isUndoOnce(userInput)) {
 		return true;
 	}
@@ -17,7 +17,7 @@ bool UndoCommandTokeniser::isValidCommand(std::string userInput) {
 }
 
 CommandTokens UndoCommandTokeniser::tokeniseUserInput(std::string userInput) {
-	assert(isValidCommand(userInput));
+	assert(canTokeniseUserInput(userInput));
 
 	CommandTokens tokenisedCommand(CommandTokens::PrimaryCommandType::Undo);
 

--- a/Parser/CommandTokenisers/UndoCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/UndoCommandTokeniser.cpp
@@ -19,6 +19,10 @@ CommandTokens UndoCommandTokeniser::tokeniseUserInput(std::string userInput) {
 	return _commandTokens;
 }
 
+bool UndoCommandTokeniser::isValidCommand(std::string userInput) {
+	return isUndoCommand(userInput);
+}
+
 bool UndoCommandTokeniser::isUndoCommand(std::string userInput) {
 	if (isUndoOnceCommand(userInput)) {
 		return true;

--- a/Parser/CommandTokenisers/UndoCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/UndoCommandTokeniser.cpp
@@ -5,37 +5,35 @@ UndoCommandTokeniser::UndoCommandTokeniser(void) {
 	// nothing here
 }
 
-
 UndoCommandTokeniser::~UndoCommandTokeniser(void) {
 	// nothing here
 }
 
-CommandTokens UndoCommandTokeniser::tokeniseUserInput(std::string userInput) {
-	_commandTokens.setPrimaryCommand(CommandTokens::PrimaryCommandType::Undo);
-
-	if (isUndoOnceCommand(userInput)) {
-		tokeniseUndoOnceCommand();
-	}
-
-	return _commandTokens;
-}
-
 bool UndoCommandTokeniser::isValidCommand(std::string userInput) {
-	return isUndoCommand(userInput);
-}
-
-bool UndoCommandTokeniser::isUndoCommand(std::string userInput) {
-	if (isUndoOnceCommand(userInput)) {
+	if (isUndoOnce(userInput)) {
 		return true;
 	}
 	return false;
 }
 
-bool UndoCommandTokeniser::isUndoOnceCommand(std::string userInput) {
-	return std::regex_match(userInput, std::regex("undo",
-	                                              std::regex_constants::ECMAScript | std::regex_constants::icase));
+CommandTokens UndoCommandTokeniser::tokeniseUserInput(std::string userInput) {
+	assert(isValidCommand(userInput));
+
+	CommandTokens tokenisedCommand(CommandTokens::PrimaryCommandType::Undo);
+
+	if (isUndoOnce(userInput)) {
+		tokeniseUndoOnce(&tokenisedCommand);
+	}
+
+	return tokenisedCommand;
 }
 
-void UndoCommandTokeniser::tokeniseUndoOnceCommand() {
-	_commandTokens.setSecondaryCommand(CommandTokens::SecondaryCommandType::None);
+bool UndoCommandTokeniser::isUndoOnce(std::string userInput) {
+	return std::regex_match(userInput,
+	                        std::regex("UNDO",
+	                                   std::regex_constants::ECMAScript | std::regex_constants::icase));
+}
+
+void UndoCommandTokeniser::tokeniseUndoOnce(CommandTokens* outputCommandTokens) {
+	outputCommandTokens->setSecondaryCommand(CommandTokens::SecondaryCommandType::None);
 }

--- a/Parser/CommandTokenisers/UndoCommandTokeniser.h
+++ b/Parser/CommandTokenisers/UndoCommandTokeniser.h
@@ -2,22 +2,15 @@
 #pragma once
 #include "..\CommandTokeniser.h"
 
-// serves two related purposes:
-// first, provides a static public method to check if an entered command is
-// indeed of Undo PrimaryCommandType
-// second, tokenises the entered command into the various arguments
 class UndoCommandTokeniser : public CommandTokeniser {
 public:
 	UndoCommandTokeniser(void);
 	virtual ~UndoCommandTokeniser(void);
-	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
-	static bool isUndoCommand(std::string userInput);
+
 	virtual bool isValidCommand(std::string userInput) override;
+	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 
 private:
-	// identifiers to determine the exact type of UNDO command called
-	static bool isUndoOnceCommand(std::string userInput);
-
-	// tokenisers for the various types of UNDO commands
-	void tokeniseUndoOnceCommand();
+	bool isUndoOnce(std::string userInput);
+	void tokeniseUndoOnce(CommandTokens* outputCommandTokens);
 };

--- a/Parser/CommandTokenisers/UndoCommandTokeniser.h
+++ b/Parser/CommandTokenisers/UndoCommandTokeniser.h
@@ -7,7 +7,7 @@ public:
 	UndoCommandTokeniser(void);
 	virtual ~UndoCommandTokeniser(void);
 
-	virtual bool isValidCommand(std::string userInput) override;
+	virtual bool canTokeniseUserInput(std::string userInput) override;
 	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 
 private:

--- a/Parser/CommandTokenisers/UndoCommandTokeniser.h
+++ b/Parser/CommandTokenisers/UndoCommandTokeniser.h
@@ -1,3 +1,4 @@
+//@@ author A0097681N
 #pragma once
 #include "..\CommandTokeniser.h"
 

--- a/Parser/CommandTokenisers/UndoCommandTokeniser.h
+++ b/Parser/CommandTokenisers/UndoCommandTokeniser.h
@@ -11,6 +11,7 @@ public:
 	virtual ~UndoCommandTokeniser(void);
 	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 	static bool isUndoCommand(std::string userInput);
+	virtual bool isValidCommand(std::string userInput) override;
 
 private:
 	// identifiers to determine the exact type of UNDO command called

--- a/Parser/CommandTokenisers/UntagCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/UntagCommandTokeniser.cpp
@@ -9,50 +9,47 @@ UntagCommandTokeniser::~UntagCommandTokeniser(void) {
 	// nothing here
 }
 
-CommandTokens UntagCommandTokeniser::tokeniseUserInput(std::string userInput) {
-	_commandTokens.setPrimaryCommand(CommandTokens::PrimaryCommandType::Untag);
-
-	if (isUntagIndexCommand(userInput)) {
-		tokeniseUntagIndexCommand(userInput);
-	}
-
-	return _commandTokens;
-}
-
 bool UntagCommandTokeniser::isValidCommand(std::string userInput) {
-	return isUntagCommand(userInput);
-}
-
-bool UntagCommandTokeniser::isUntagCommand(std::string userInput) {
-	if (isUntagIndexCommand(userInput)) {
+	if (isUntagIndex(userInput)) {
 		return true;
 	}
 	return false;
 }
 
-bool UntagCommandTokeniser::isUntagIndexCommand(std::string userInput) {
+CommandTokens UntagCommandTokeniser::tokeniseUserInput(std::string userInput) {
+	assert(isValidCommand(userInput));
+
+	CommandTokens tokenisedCommand(CommandTokens::PrimaryCommandType::Untag);
+
+	if (isUntagIndex(userInput)) {
+		tokeniseUntagIndex(userInput, &tokenisedCommand);
+	}
+
+	return tokenisedCommand;
+}
+
+bool UntagCommandTokeniser::isUntagIndex(std::string userInput) {
 	return std::regex_match(userInput,
-	                        std::regex("untag [0-9]+( (#[^ ]+))+",
+	                        std::regex("UNTAG [0-9]+( (#[^ ]+))+",
 	                                   std::regex_constants::ECMAScript | std::regex_constants::icase));
 }
 
-void UntagCommandTokeniser::tokeniseUntagIndexCommand(std::string userInput) {
-	_commandTokens.setSecondaryCommand(CommandTokens::SecondaryCommandType::Index);
+void UntagCommandTokeniser::tokeniseUntagIndex(std::string userInput, CommandTokens* outputCommandTokens) {
+	outputCommandTokens->setSecondaryCommand(CommandTokens::SecondaryCommandType::Index);
 
 	std::smatch matchResults;
 	std::regex_match(userInput, matchResults,
-	                 std::regex("untag ([0-9]+) .*",
+	                 std::regex("UNTAG ([0-9]+) .*",
 	                            std::regex_constants::ECMAScript | std::regex_constants::icase));
 
 	int index = stoi(matchResults[1]);
-	_commandTokens.setIndex(index);
+	outputCommandTokens->setIndex(index);
 
-	tokeniseTags(userInput);
+	tokeniseTags(userInput, outputCommandTokens);
 }
 
-void UntagCommandTokeniser::tokeniseTags(std::string userInput) {
+void UntagCommandTokeniser::tokeniseTags(std::string userInput, CommandTokens* outputCommandTokens) {
 	std::vector<std::string> newTags;
-
 	std::smatch matchResults;
 	while (std::regex_search(userInput, matchResults,
 	                         std::regex(" (#[^ ]+)",
@@ -64,5 +61,5 @@ void UntagCommandTokeniser::tokeniseTags(std::string userInput) {
 		userInput = matchResults.suffix().str();
 	}
 
-	_commandTokens.setTags(newTags);
+	outputCommandTokens->setTags(newTags);
 }

--- a/Parser/CommandTokenisers/UntagCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/UntagCommandTokeniser.cpp
@@ -9,7 +9,7 @@ UntagCommandTokeniser::~UntagCommandTokeniser(void) {
 	// nothing here
 }
 
-bool UntagCommandTokeniser::isValidCommand(std::string userInput) {
+bool UntagCommandTokeniser::canTokeniseUserInput(std::string userInput) {
 	if (isUntagIndex(userInput)) {
 		return true;
 	}
@@ -17,7 +17,7 @@ bool UntagCommandTokeniser::isValidCommand(std::string userInput) {
 }
 
 CommandTokens UntagCommandTokeniser::tokeniseUserInput(std::string userInput) {
-	assert(isValidCommand(userInput));
+	assert(canTokeniseUserInput(userInput));
 
 	CommandTokens tokenisedCommand(CommandTokens::PrimaryCommandType::Untag);
 

--- a/Parser/CommandTokenisers/UntagCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/UntagCommandTokeniser.cpp
@@ -1,5 +1,5 @@
+//@@ author A0097681N
 #include "UntagCommandTokeniser.h"
-
 
 UntagCommandTokeniser::UntagCommandTokeniser(void) {
 	// nothing here

--- a/Parser/CommandTokenisers/UntagCommandTokeniser.cpp
+++ b/Parser/CommandTokenisers/UntagCommandTokeniser.cpp
@@ -19,6 +19,10 @@ CommandTokens UntagCommandTokeniser::tokeniseUserInput(std::string userInput) {
 	return _commandTokens;
 }
 
+bool UntagCommandTokeniser::isValidCommand(std::string userInput) {
+	return isUntagCommand(userInput);
+}
+
 bool UntagCommandTokeniser::isUntagCommand(std::string userInput) {
 	if (isUntagIndexCommand(userInput)) {
 		return true;

--- a/Parser/CommandTokenisers/UntagCommandTokeniser.h
+++ b/Parser/CommandTokenisers/UntagCommandTokeniser.h
@@ -1,3 +1,4 @@
+//@@ author A0097681N
 #pragma once
 #include "..\CommandTokeniser.h"
 

--- a/Parser/CommandTokenisers/UntagCommandTokeniser.h
+++ b/Parser/CommandTokenisers/UntagCommandTokeniser.h
@@ -11,6 +11,7 @@ public:
 	virtual ~UntagCommandTokeniser(void);
 	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 	static bool isUntagCommand(std::string userInput);
+	virtual bool isValidCommand(std::string userInput) override;
 
 private:
 	// identifiers to determine the exact type of UNTAG command called

--- a/Parser/CommandTokenisers/UntagCommandTokeniser.h
+++ b/Parser/CommandTokenisers/UntagCommandTokeniser.h
@@ -7,7 +7,7 @@ public:
 	UntagCommandTokeniser(void);
 	virtual ~UntagCommandTokeniser(void);
 
-	virtual bool isValidCommand(std::string userInput) override;
+	virtual bool canTokeniseUserInput(std::string userInput) override;
 	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 
 private:

--- a/Parser/CommandTokenisers/UntagCommandTokeniser.h
+++ b/Parser/CommandTokenisers/UntagCommandTokeniser.h
@@ -2,24 +2,16 @@
 #pragma once
 #include "..\CommandTokeniser.h"
 
-// serves two related purposes:
-// first, provides a static public method to check if an entered command is
-// indeed of Untag PrimaryCommandType
-// second, tokenises the entered command into the various arguments
 class UntagCommandTokeniser : public CommandTokeniser {
 public:
 	UntagCommandTokeniser(void);
 	virtual ~UntagCommandTokeniser(void);
-	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
-	static bool isUntagCommand(std::string userInput);
+
 	virtual bool isValidCommand(std::string userInput) override;
+	virtual CommandTokens tokeniseUserInput(std::string userInput) override;
 
 private:
-	// identifiers to determine the exact type of UNTAG command called
-	static bool isUntagIndexCommand(std::string userInput);
-
-	// tokenisers for the various types of UNTAG commands
-	void tokeniseUntagIndexCommand(std::string userInput);
-
-	void tokeniseTags(std::string userInput);
+	bool isUntagIndex(std::string userInput);
+	void tokeniseUntagIndex(std::string userInput, CommandTokens* outputCommandTokens);
+	void tokeniseTags(std::string userInput, CommandTokens* outputCommandTokens);
 };

--- a/Parser/CommandTokens.cpp
+++ b/Parser/CommandTokens.cpp
@@ -17,7 +17,7 @@ CommandTokens::CommandTokens(PrimaryCommandType primaryCommandType,
 	_index(index) {
 }
 
-void CommandTokens::resetMemberVariables() {
+void CommandTokens::reset() {
 	_primaryCommandType = Invalid;
 	_secondaryCommandType = None;
 	_taskName = "";
@@ -33,7 +33,6 @@ bool CommandTokens::isValid() {
 	return _primaryCommandType == Invalid;
 }
 
-// getters
 CommandTokens::PrimaryCommandType CommandTokens::getPrimaryCommand() {
 	return _primaryCommandType;
 }
@@ -66,7 +65,6 @@ std::string CommandTokens::getOtherCommandParameter() {
 	return _otherCommandParameter;
 }
 
-// setters
 void CommandTokens::setPrimaryCommand(PrimaryCommandType newPrimaryCommand) {
 	_primaryCommandType = newPrimaryCommand;
 }

--- a/Parser/CommandTokens.cpp
+++ b/Parser/CommandTokens.cpp
@@ -1,3 +1,4 @@
+//@@ author A0097681N
 #include "CommandTokens.h"
 
 // complete constructor, with default arguments initialised to sentinel values

--- a/Parser/CommandTokens.h
+++ b/Parser/CommandTokens.h
@@ -1,3 +1,4 @@
+//@@ author A0097681N
 #pragma once
 #include <exception>
 #include <vector>

--- a/Parser/CommandTokens.h
+++ b/Parser/CommandTokens.h
@@ -5,7 +5,6 @@
 
 class CommandTokens {
 public:
-
 	// Command Type for main groups of operation
 	enum PrimaryCommandType {
 		Add,
@@ -54,7 +53,7 @@ public:
 	              int index = -1);
 
 	bool isValid();
-	void resetMemberVariables();
+	void reset();
 
 	PrimaryCommandType getPrimaryCommand();
 	SecondaryCommandType getSecondaryCommand();

--- a/Parser/DateParser.cpp
+++ b/Parser/DateParser.cpp
@@ -1,3 +1,4 @@
+//@@ author A0097681N
 #include "DateParser.h"
 #include "boost\date_time\posix_time\time_parsers.hpp"
 

--- a/Parser/DateParser.h
+++ b/Parser/DateParser.h
@@ -1,3 +1,4 @@
+//@@ author A0097681N
 #pragma once
 #include <regex>
 #include "../boost/date_time/posix_time/ptime.hpp"

--- a/Parser/Parser.cpp
+++ b/Parser/Parser.cpp
@@ -52,7 +52,7 @@ CommandTokens Parser::parse(std::string userInput) {
 
 CommandTokeniser* Parser::getCommandTokeniser(std::string userInput) {
 	for (CommandTokeniser* commandTokeniser : _commandTokenisers) {
-		if (commandTokeniser->isValidCommand(userInput)) {
+		if (commandTokeniser->canTokeniseUserInput(userInput)) {
 			return commandTokeniser;
 		}
 	}

--- a/Parser/Parser.cpp
+++ b/Parser/Parser.cpp
@@ -1,4 +1,17 @@
 #include "Parser.h"
+#include "CommandTokenisers\AddCommandTokeniser.h"
+#include "CommandTokenisers\ConfigureCommandTokeniser.h"
+#include "CommandTokenisers\CompleteCommandTokeniser.h"
+#include "CommandTokenisers\DeleteCommandTokeniser.h"
+#include "CommandTokenisers\DisplayCommandTokeniser.h"
+#include "CommandTokenisers\ExportCommandTokeniser.h"
+#include "CommandTokenisers\EditCommandTokeniser.h"
+#include "CommandTokenisers\ImportCommandTokeniser.h"
+#include "CommandTokenisers\RefreshCommandTokeniser.h"
+#include "CommandTokenisers\SearchCommandTokeniser.h"
+#include "CommandTokenisers\TagCommandTokeniser.h"
+#include "CommandTokenisers\UndoCommandTokeniser.h"
+#include "CommandTokenisers\UntagCommandTokeniser.h"
 
 Parser::Parser(void) {
 	_logger = Logger::getInstance();
@@ -6,13 +19,27 @@ Parser::Parser(void) {
 	_commandTokeniser = nullptr;
 	_invalidCommandTokens.setPrimaryCommand(CommandTokens::PrimaryCommandType::Invalid);
 	_invalidCommandTokens.setSecondaryCommand(CommandTokens::SecondaryCommandType::None);
+
+	_commandTokenisers.push_back(new AddCommandTokeniser);
+	_commandTokenisers.push_back(new ConfigureCommandTokeniser);
+	_commandTokenisers.push_back(new CompleteCommandTokeniser);
+	_commandTokenisers.push_back(new DeleteCommandTokeniser);
+	_commandTokenisers.push_back(new DisplayCommandTokeniser);
+	_commandTokenisers.push_back(new ExportCommandTokeniser);
+	_commandTokenisers.push_back(new EditCommandTokeniser);
+	_commandTokenisers.push_back(new ImportCommandTokeniser);
+	_commandTokenisers.push_back(new RefreshCommandTokeniser);
+	_commandTokenisers.push_back(new SearchCommandTokeniser);
+	_commandTokenisers.push_back(new TagCommandTokeniser);
+	_commandTokenisers.push_back(new UndoCommandTokeniser);
+	_commandTokenisers.push_back(new UntagCommandTokeniser);
 }
 
 CommandTokens Parser::parse(std::string userInput) {
 	_logger->logINFO("Parser::parse(std::string userInput):CommandTokens called with parameter userInput=\"" + userInput + "\"");
 
 	try {
-		selectCommandTokeniser(userInput);
+		_commandTokeniser = getCommandTokeniser(userInput);
 	} catch (CommandDoesNotExistException& e) {
 		_logger->logINFO(e.what());
 		return _invalidCommandTokens;
@@ -21,87 +48,12 @@ CommandTokens Parser::parse(std::string userInput) {
 	return _commandTokeniser->tokeniseUserInput(userInput);
 }
 
-void Parser::selectCommandTokeniser(std::string userInput) {
-	if (isAddCommand(userInput)) {
-		_commandTokeniser = &_addCommandTokeniser;
-	} else if (isConfigureCommand(userInput)) {
-		_commandTokeniser = &_configureCommandTokeniser;
-	} else if (isCompleteCommand(userInput)) {
-		_commandTokeniser = &_completeCommandTokeniser;
-	} else if (isDeleteCommand(userInput)) {
-		_commandTokeniser = &_deleteCommandTokeniser;
-	} else if (isDisplayCommand(userInput)) {
-		_commandTokeniser = &_displayCommandTokeniser;
-	} else if (isEditCommand(userInput)) {
-		_commandTokeniser = &_editCommandTokeniser;
-	} else if (isExportCommand(userInput)) {
-		_commandTokeniser = &_exportCommandTokeniser;
-	} else if (isImportCommand(userInput)) {
-		_commandTokeniser = &_importCommandTokeniser;
-	} else if (isRefreshCommand(userInput)) {
-		_commandTokeniser = &_refreshCommandTokeniser;
-	} else if (isSearchCommand(userInput)) {
-		_commandTokeniser = &_searchCommandTokeniser;
-	} else if (isTagCommand(userInput)) {
-		_commandTokeniser = &_tagCommandTokeniser;
-	} else if (isUndoCommand(userInput)) {
-		_commandTokeniser = &_undoCommandTokeniser;
-	} else if (isUntagCommand(userInput)) {
-		_commandTokeniser = &_untagCommandTokeniser;
-	} else {
-		_commandTokeniser = nullptr;
-		throw CommandDoesNotExistException();
+CommandTokeniser* Parser::getCommandTokeniser(std::string userInput) {
+	for (CommandTokeniser* commandTokeniser : _commandTokenisers) {
+		if (commandTokeniser->isValidCommand(userInput)) {
+			return commandTokeniser;
+		}
 	}
-}
 
-bool Parser::isAddCommand(std::string& userInput) {
-	return AddCommandTokeniser::isAddCommand(userInput);
-}
-
-bool Parser::isConfigureCommand(std::string& userInput) {
-	return ConfigureCommandTokeniser::isConfigureCommand(userInput);
-}
-
-bool Parser::isCompleteCommand(std::string& userInput) {
-	return CompleteCommandTokeniser::isCompleteCommand(userInput);
-}
-
-bool Parser::isDeleteCommand(std::string& userInput) {
-	return DeleteCommandTokeniser::isDeleteCommand(userInput);
-}
-
-bool Parser::isDisplayCommand(std::string& userInput) {
-	return DisplayCommandTokeniser::isDisplayCommand(userInput);
-}
-
-bool Parser::isEditCommand(std::string& userInput) {
-	return EditCommandTokeniser::isEditCommand(userInput);
-}
-
-bool Parser::isImportCommand(std::string& userInput) {
-	return ImportCommandTokeniser::isImportCommand(userInput);
-}
-
-bool Parser::isExportCommand(std::string& userInput) {
-	return ExportCommandTokeniser::isExportCommand(userInput);
-}
-
-bool Parser::isSearchCommand(std::string& userInput) {
-	return SearchCommandTokeniser::isSearchCommand(userInput);
-}
-
-bool Parser::isRefreshCommand(std::string& userInput) {
-	return RefreshCommandTokeniser::isRefreshCommand(userInput);
-}
-
-bool Parser::isTagCommand(std::string& userInput) {
-	return TagCommandTokeniser::isTagCommand(userInput);
-}
-
-bool Parser::isUndoCommand(std::string& userInput) {
-	return UndoCommandTokeniser::isUndoCommand(userInput);
-}
-
-bool Parser::isUntagCommand(std::string& userInput) {
-	return UntagCommandTokeniser::isUntagCommand(userInput);
+	throw CommandDoesNotExistException();
 }

--- a/Parser/Parser.cpp
+++ b/Parser/Parser.cpp
@@ -1,4 +1,6 @@
+//@@ author A0097681N
 #include "Parser.h"
+
 #include "CommandTokenisers\AddCommandTokeniser.h"
 #include "CommandTokenisers\ConfigureCommandTokeniser.h"
 #include "CommandTokenisers\CompleteCommandTokeniser.h"

--- a/Parser/Parser.h
+++ b/Parser/Parser.h
@@ -1,3 +1,4 @@
+//@@ author A0097681N
 #pragma once
 #include <regex>
 #include "CommandTokens.h"

--- a/Parser/Parser.h
+++ b/Parser/Parser.h
@@ -3,19 +3,6 @@
 #include "CommandTokens.h"
 #include "CommandTokeniser.h"
 #include "Logger\Logger.h"
-#include "CommandTokenisers\AddCommandTokeniser.h"
-#include "CommandTokenisers\ConfigureCommandTokeniser.h"
-#include "CommandTokenisers\CompleteCommandTokeniser.h"
-#include "CommandTokenisers\DeleteCommandTokeniser.h"
-#include "CommandTokenisers\DisplayCommandTokeniser.h"
-#include "CommandTokenisers\ExportCommandTokeniser.h"
-#include "CommandTokenisers\EditCommandTokeniser.h"
-#include "CommandTokenisers\ImportCommandTokeniser.h"
-#include "CommandTokenisers\RefreshCommandTokeniser.h"
-#include "CommandTokenisers\SearchCommandTokeniser.h"
-#include "CommandTokenisers\TagCommandTokeniser.h"
-#include "CommandTokenisers\UndoCommandTokeniser.h"
-#include "CommandTokenisers\UntagCommandTokeniser.h"
 
 // facade class to provide uniform way to assess the various CommandTokenisers
 class Parser {
@@ -26,36 +13,9 @@ public:
 private:
 	Logger* _logger;
 
+	std::vector<CommandTokeniser*> _commandTokenisers;
 	CommandTokeniser* _commandTokeniser;
 	CommandTokens _invalidCommandTokens;
 
-	AddCommandTokeniser _addCommandTokeniser;
-	ConfigureCommandTokeniser _configureCommandTokeniser;
-	CompleteCommandTokeniser _completeCommandTokeniser;
-	DeleteCommandTokeniser _deleteCommandTokeniser;
-	DisplayCommandTokeniser _displayCommandTokeniser;
-	ExportCommandTokeniser _exportCommandTokeniser;
-	EditCommandTokeniser _editCommandTokeniser;
-	ImportCommandTokeniser _importCommandTokeniser;
-	RefreshCommandTokeniser _refreshCommandTokeniser;
-	SearchCommandTokeniser _searchCommandTokeniser;
-	TagCommandTokeniser _tagCommandTokeniser;
-	UndoCommandTokeniser _undoCommandTokeniser;
-	UntagCommandTokeniser _untagCommandTokeniser;
-
-	void selectCommandTokeniser(std::string userInput);
-
-	bool isAddCommand(std::string& userInput);
-	bool isConfigureCommand(std::string& userInput);
-	bool isCompleteCommand(std::string& userInput);
-	bool isDeleteCommand(std::string& userInput);
-	bool isEditCommand(std::string& userInput);
-	bool isDisplayCommand(std::string& userInput);
-	bool isExportCommand(std::string& userInput);
-	bool isImportCommand(std::string& userInput);
-	bool isRefreshCommand(std::string& userInput);
-	bool isSearchCommand(std::string& userInput);
-	bool isTagCommand(std::string& userInput);
-	bool isUndoCommand(std::string& userInput);
-	bool isUntagCommand(std::string& userInput);
+	CommandTokeniser* getCommandTokeniser(std::string userInput);
 };

--- a/ParserTest/ParserTest.cpp
+++ b/ParserTest/ParserTest.cpp
@@ -108,6 +108,20 @@ namespace ParserTest {
 			compareCommandTokens(expected, actual);
 		}
 
+		TEST_METHOD(unitTest_parser_TokeniseDeleteCompleted) {
+			std::string testUserInput = "DELETE COMPLETED";
+			CommandTokens actual, expected;
+			actual = _parser.parse(testUserInput);
+			expected = buildExpectedCommandTokens(CommandTokens::PrimaryCommandType::Delete,
+			                                      CommandTokens::SecondaryCommandType::Completed,
+			                                      "",
+			                                      "",
+			                                      "",
+			                                      -1);
+
+			compareCommandTokens(expected, actual);
+		}
+
 		TEST_METHOD(unitTest_parser_TokeniseDeleteBy) {
 			std::string testUserInput = "DELETE BY 2002-01-22 23:59:59.000";
 			CommandTokens actual, expected;
@@ -420,6 +434,17 @@ namespace ParserTest {
 			DateParser dateParser;
 
 			boost::posix_time::ptime expected(boost::posix_time::time_from_string("1999-05-13 13:20:00.000"));
+			boost::posix_time::ptime actual;
+			actual = dateParser.parse(testUserInputDate);
+			
+			Assert::IsTrue(expected == actual);
+		}
+
+		TEST_METHOD(unitTest_parser_DateParser_DD_MM_YYYY) {
+			std::string testUserInputDate = "13-05-1999";
+			DateParser dateParser;
+
+			boost::posix_time::ptime expected(boost::posix_time::time_from_string("1999-05-13 00:00:00.000"));
 			boost::posix_time::ptime actual;
 			actual = dateParser.parse(testUserInputDate);
 			

--- a/ParserTest/ParserTest.cpp
+++ b/ParserTest/ParserTest.cpp
@@ -1,3 +1,4 @@
+//@@ author A0097681N
 #include "stdafx.h"
 #include "CppUnitTest.h"
 

--- a/ParserTest/ParserTest.cpp
+++ b/ParserTest/ParserTest.cpp
@@ -8,7 +8,7 @@ namespace ParserTest {
 	public:
 		Parser _parser;
 
-		TEST_METHOD(unitTest_parser_TokeniseAddActivityCommand) {
+		TEST_METHOD(unitTest_parser_TokeniseAddFromToCommand) {
 			std::string testUserInput = "ADD activityTask FROM 2002-01-20 23:59:59.000 TO 2002-01-22 23:59:59.000";
 			CommandTokens actual, expected;
 
@@ -23,7 +23,7 @@ namespace ParserTest {
 			compareCommandTokens(expected, actual);
 		}
 
-		TEST_METHOD(unitTest_parser_TokeniseAddTodoCommand) {
+		TEST_METHOD(unitTest_parser_TokeniseAddByCommand) {
 			std::string testUserInput = "ADD todoTask BY 2002-01-22 23:59:59.000";
 			CommandTokens actual, expected;
 

--- a/ParserTest/ParserTest.cpp
+++ b/ParserTest/ParserTest.cpp
@@ -9,7 +9,7 @@ namespace ParserTest {
 	public:
 		Parser _parser;
 
-		TEST_METHOD(unitTest_parser_TokeniseAddFromToCommand) {
+		TEST_METHOD(unitTest_parser_TokeniseAddFromTo) {
 			std::string testUserInput = "ADD activityTask FROM 2002-01-20 23:59:59.000 TO 2002-01-22 23:59:59.000";
 			CommandTokens actual, expected;
 
@@ -24,7 +24,7 @@ namespace ParserTest {
 			compareCommandTokens(expected, actual);
 		}
 
-		TEST_METHOD(unitTest_parser_TokeniseAddByCommand) {
+		TEST_METHOD(unitTest_parser_TokeniseAddBy) {
 			std::string testUserInput = "ADD todoTask BY 2002-01-22 23:59:59.000";
 			CommandTokens actual, expected;
 
@@ -39,7 +39,7 @@ namespace ParserTest {
 			compareCommandTokens(expected, actual);
 		}
 
-		TEST_METHOD(unitTest_parser_TokeniseAddFloatingCommand) {
+		TEST_METHOD(unitTest_parser_TokeniseAddFloating) {
 			std::string testUserInput = "ADD floatingTask";
 			CommandTokens actual, expected;
 			actual = _parser.parse(testUserInput);
@@ -53,7 +53,7 @@ namespace ParserTest {
 			compareCommandTokens(expected, actual);
 		}
 
-		TEST_METHOD(unitTest_parser_TokeniseCompleteCommand) {
+		TEST_METHOD(unitTest_parser_TokeniseComplete) {
 			std::string testUserInput = "COMPLETE 11";
 			CommandTokens actual, expected;
 			actual = _parser.parse(testUserInput);
@@ -67,7 +67,7 @@ namespace ParserTest {
 			compareCommandTokens(expected, actual);
 		}
 
-		TEST_METHOD(unitTest_parser_TokeniseConfigureSaveLocationCommand) {
+		TEST_METHOD(unitTest_parser_TokeniseConfigureSaveLocation) {
 			std::string testUserInput = "CONFIGURE SAVE LOCATION D:\\";
 			CommandTokens actual, expected;
 			actual = _parser.parse(testUserInput);
@@ -77,36 +77,8 @@ namespace ParserTest {
 			                                      "",
 			                                      "",
 			                                      -1);
-			
+
 			expected.setOtherCommandParameter("D:\\");
-			compareCommandTokens(expected, actual);
-		}
-
-		TEST_METHOD(unitTest_parser_TokeniseDeleteFromTo) {
-			std::string testUserInput = "DELETE FROM 2002-01-20 23:59:59.000 TO 2002-01-22 23:59:59.000";
-			CommandTokens actual, expected;
-			actual = _parser.parse(testUserInput);
-			expected = buildExpectedCommandTokens(CommandTokens::PrimaryCommandType::Delete,
-			                                      CommandTokens::SecondaryCommandType::Timed,
-			                                      "",
-			                                      "2002-01-20 23:59:59.000",
-			                                      "2002-01-22 23:59:59.000",
-			                                      -1);
-
-			compareCommandTokens(expected, actual);
-		}
-
-		TEST_METHOD(unitTest_parser_TokeniseDeleteFrom) {
-			std::string testUserInput = "DELETE FROM 2002-01-20 23:59:59.000";
-			CommandTokens actual, expected;
-			actual = _parser.parse(testUserInput);
-			expected = buildExpectedCommandTokens(CommandTokens::PrimaryCommandType::Delete,
-			                                      CommandTokens::SecondaryCommandType::Start,
-			                                      "",
-			                                      "2002-01-20 23:59:59.000",
-			                                      "",
-			                                      -1);
-
 			compareCommandTokens(expected, actual);
 		}
 
@@ -138,20 +110,6 @@ namespace ParserTest {
 			compareCommandTokens(expected, actual);
 		}
 
-		TEST_METHOD(unitTest_parser_TokeniseDeleteBy) {
-			std::string testUserInput = "DELETE BY 2002-01-22 23:59:59.000";
-			CommandTokens actual, expected;
-			actual = _parser.parse(testUserInput);
-			expected = buildExpectedCommandTokens(CommandTokens::PrimaryCommandType::Delete,
-			                                      CommandTokens::SecondaryCommandType::Todo,
-			                                      "",
-			                                      "",
-			                                      "2002-01-22 23:59:59.000",
-			                                      -1);
-
-			compareCommandTokens(expected, actual);
-		}
-
 		TEST_METHOD(unitTest_parser_TokeniseDeleteIndex) {
 			std::string testUserInput = "DELETE 3";
 			CommandTokens actual, expected;
@@ -166,11 +124,11 @@ namespace ParserTest {
 			compareCommandTokens(expected, actual);
 		}
 
-		TEST_METHOD(unitTest_parser_TokeniseDisplayBy) {
-			std::string testUserInput = "DISPLAY BY 2002-01-22 23:59:59.000";
+		TEST_METHOD(unitTest_parser_TokeniseDeleteBy) {
+			std::string testUserInput = "DELETE BY 2002-01-22 23:59:59.000";
 			CommandTokens actual, expected;
 			actual = _parser.parse(testUserInput);
-			expected = buildExpectedCommandTokens(CommandTokens::PrimaryCommandType::Display,
+			expected = buildExpectedCommandTokens(CommandTokens::PrimaryCommandType::Delete,
 			                                      CommandTokens::SecondaryCommandType::Todo,
 			                                      "",
 			                                      "",
@@ -180,11 +138,25 @@ namespace ParserTest {
 			compareCommandTokens(expected, actual);
 		}
 
-		TEST_METHOD(unitTest_parser_TokeniseDisplayFrom) {
-			std::string testUserInput = "DISPLAY FROM 2002-01-20 23:59:59.000";
+		TEST_METHOD(unitTest_parser_TokeniseDeleteFromTo) {
+			std::string testUserInput = "DELETE FROM 2002-01-20 23:59:59.000 TO 2002-01-22 23:59:59.000";
 			CommandTokens actual, expected;
 			actual = _parser.parse(testUserInput);
-			expected = buildExpectedCommandTokens(CommandTokens::PrimaryCommandType::Display,
+			expected = buildExpectedCommandTokens(CommandTokens::PrimaryCommandType::Delete,
+			                                      CommandTokens::SecondaryCommandType::Timed,
+			                                      "",
+			                                      "2002-01-20 23:59:59.000",
+			                                      "2002-01-22 23:59:59.000",
+			                                      -1);
+
+			compareCommandTokens(expected, actual);
+		}
+
+		TEST_METHOD(unitTest_parser_TokeniseDeleteFrom) {
+			std::string testUserInput = "DELETE FROM 2002-01-20 23:59:59.000";
+			CommandTokens actual, expected;
+			actual = _parser.parse(testUserInput);
+			expected = buildExpectedCommandTokens(CommandTokens::PrimaryCommandType::Delete,
 			                                      CommandTokens::SecondaryCommandType::Start,
 			                                      "",
 			                                      "2002-01-20 23:59:59.000",
@@ -222,7 +194,49 @@ namespace ParserTest {
 			compareCommandTokens(expected, actual);
 		}
 
-		TEST_METHOD(unitTest_parser_TokeniseEditNameCommand) {
+		TEST_METHOD(unitTest_parser_TokeniseDisplayBy) {
+			std::string testUserInput = "DISPLAY BY 2002-01-22 23:59:59.000";
+			CommandTokens actual, expected;
+			actual = _parser.parse(testUserInput);
+			expected = buildExpectedCommandTokens(CommandTokens::PrimaryCommandType::Display,
+			                                      CommandTokens::SecondaryCommandType::Todo,
+			                                      "",
+			                                      "",
+			                                      "2002-01-22 23:59:59.000",
+			                                      -1);
+
+			compareCommandTokens(expected, actual);
+		}
+
+		TEST_METHOD(unitTest_parser_TokeniseDisplayFromTo) {
+			std::string testUserInput = "DISPLAY FROM 2002-01-20 23:59:59.000 TO 2002-01-22 23:59:59.000";
+			CommandTokens actual, expected;
+			actual = _parser.parse(testUserInput);
+			expected = buildExpectedCommandTokens(CommandTokens::PrimaryCommandType::Display,
+			                                      CommandTokens::SecondaryCommandType::Timed,
+			                                      "",
+			                                      "2002-01-20 23:59:59.000",
+			                                      "2002-01-22 23:59:59.000",
+			                                      -1);
+
+			compareCommandTokens(expected, actual);
+		}
+
+		TEST_METHOD(unitTest_parser_TokeniseDisplayFrom) {
+			std::string testUserInput = "DISPLAY FROM 2002-01-20 23:59:59.000";
+			CommandTokens actual, expected;
+			actual = _parser.parse(testUserInput);
+			expected = buildExpectedCommandTokens(CommandTokens::PrimaryCommandType::Display,
+			                                      CommandTokens::SecondaryCommandType::Start,
+			                                      "",
+			                                      "2002-01-20 23:59:59.000",
+			                                      "",
+			                                      -1);
+
+			compareCommandTokens(expected, actual);
+		}
+
+		TEST_METHOD(unitTest_parser_TokeniseEditName) {
 			std::string testUserInput = "EDIT NAME 3 newTaskName";
 			CommandTokens actual, expected;
 			actual = _parser.parse(testUserInput);
@@ -236,7 +250,7 @@ namespace ParserTest {
 			compareCommandTokens(expected, actual);
 		}
 
-		TEST_METHOD(unitTest_parser_TokeniseEditStartDateCommand) {
+		TEST_METHOD(unitTest_parser_TokeniseEditStartDate) {
 			std::string testUserInput = "EDIT START 5 2002-01-20 23:59:59.000";
 			CommandTokens actual, expected;
 			actual = _parser.parse(testUserInput);
@@ -250,7 +264,7 @@ namespace ParserTest {
 			compareCommandTokens(expected, actual);
 		}
 
-		TEST_METHOD(unitTest_parser_TokeniseEditEndDateCommand) {
+		TEST_METHOD(unitTest_parser_TokeniseEditEndDate) {
 			std::string testUserInput = "EDIT END 7 2002-01-20 23:59:59.000";
 			CommandTokens actual, expected;
 			actual = _parser.parse(testUserInput);
@@ -264,7 +278,7 @@ namespace ParserTest {
 			compareCommandTokens(expected, actual);
 		}
 
-		TEST_METHOD(unitTest_parser_TokeniseExportCommand) {
+		TEST_METHOD(unitTest_parser_TokeniseExport) {
 			std::string testUserInput = "EXPORT C:\\";
 			CommandTokens actual, expected;
 			actual = _parser.parse(testUserInput);
@@ -279,7 +293,7 @@ namespace ParserTest {
 			compareCommandTokens(expected, actual);
 		}
 
-		TEST_METHOD(unitTest_parser_TokeniseImportCommand) {
+		TEST_METHOD(unitTest_parser_TokeniseImport) {
 			std::string testUserInput = "IMPORT D:\\aRandomFile.txt";
 			CommandTokens actual, expected;
 			actual = _parser.parse(testUserInput);
@@ -294,7 +308,7 @@ namespace ParserTest {
 			compareCommandTokens(expected, actual);
 		}
 
-		TEST_METHOD(unitTest_parser_TokeniseRefreshCommand) {
+		TEST_METHOD(unitTest_parser_TokeniseRefresh) {
 			std::string testUserInput = "REFRESH";
 			CommandTokens actual, expected;
 			actual = _parser.parse(testUserInput);
@@ -308,8 +322,8 @@ namespace ParserTest {
 			compareCommandTokens(expected, actual);
 		}
 
-		TEST_METHOD(unitTest_parser_TokeniseSearchNameCommand) {
-			std::string testUserInput = "Search Name a Random Task";
+		TEST_METHOD(unitTest_parser_TokeniseSearchName) {
+			std::string testUserInput = "SEARCH NAME a Random Task";
 			CommandTokens actual, expected;
 			actual = _parser.parse(testUserInput);
 			expected = buildExpectedCommandTokens(CommandTokens::PrimaryCommandType::Search,
@@ -322,8 +336,8 @@ namespace ParserTest {
 			compareCommandTokens(expected, actual);
 		}
 
-		TEST_METHOD(unitTest_parser_TokeniseSearchStartBeforeCommand) {
-			std::string testUserInput = "Search Start Before 2002-01-20 23:59:59.000";
+		TEST_METHOD(unitTest_parser_TokeniseSearchStartBefore) {
+			std::string testUserInput = "SEARCH START BEFORE 2002-01-20 23:59:59.000";
 			CommandTokens actual, expected;
 			actual = _parser.parse(testUserInput);
 			expected = buildExpectedCommandTokens(CommandTokens::PrimaryCommandType::Search,
@@ -336,8 +350,8 @@ namespace ParserTest {
 			compareCommandTokens(expected, actual);
 		}
 
-		TEST_METHOD(unitTest_parser_TokeniseSearchStartAfterCommand) {
-			std::string testUserInput = "Search Start After 2002-01-20 23:59:59.000";
+		TEST_METHOD(unitTest_parser_TokeniseSearchStartAfter) {
+			std::string testUserInput = "SEARCH START AFTER 2002-01-20 23:59:59.000";
 			CommandTokens actual, expected;
 			actual = _parser.parse(testUserInput);
 			expected = buildExpectedCommandTokens(CommandTokens::PrimaryCommandType::Search,
@@ -350,8 +364,8 @@ namespace ParserTest {
 			compareCommandTokens(expected, actual);
 		}
 
-		TEST_METHOD(unitTest_parser_TokeniseSearchEndBeforeCommand) {
-			std::string testUserInput = "Search End Before 2002-01-20 23:59:59.000";
+		TEST_METHOD(unitTest_parser_TokeniseSearchEndBefore) {
+			std::string testUserInput = "SEARCH END BEFORE 2002-01-20 23:59:59.000";
 			CommandTokens actual, expected;
 			actual = _parser.parse(testUserInput);
 			expected = buildExpectedCommandTokens(CommandTokens::PrimaryCommandType::Search,
@@ -364,8 +378,8 @@ namespace ParserTest {
 			compareCommandTokens(expected, actual);
 		}
 
-		TEST_METHOD(unitTest_parser_TokeniseSearchEndAfterCommand) {
-			std::string testUserInput = "Search End After 2002-01-20 23:59:59.000";
+		TEST_METHOD(unitTest_parser_TokeniseSearchEndAfter) {
+			std::string testUserInput = "SEARCH END AFTER 2002-01-20 23:59:59.000";
 			CommandTokens actual, expected;
 			actual = _parser.parse(testUserInput);
 			expected = buildExpectedCommandTokens(CommandTokens::PrimaryCommandType::Search,
@@ -378,8 +392,8 @@ namespace ParserTest {
 			compareCommandTokens(expected, actual);
 		}
 
-		TEST_METHOD(unitTest_parser_TokeniseSearchTagsCommand) {
-			std::string testUserInput = "Search Tags #123";
+		TEST_METHOD(unitTest_parser_TokeniseSearchTags) {
+			std::string testUserInput = "SEARCH TAGS #123";
 			CommandTokens actual, expected;
 			actual = _parser.parse(testUserInput);
 			expected = buildExpectedCommandTokens(CommandTokens::PrimaryCommandType::Search,
@@ -388,14 +402,14 @@ namespace ParserTest {
 			                                      "",
 			                                      "",
 			                                      -1);
-			std::vector< std::string > newTags;
+			std::vector<std::string> newTags;
 			newTags.push_back("#123");
 			expected.setTags(newTags);
 
 			compareCommandTokens(expected, actual);
 		}
 
-		TEST_METHOD(unitTest_parser_TokeniseTagCommand) {
+		TEST_METHOD(unitTest_parser_TokeniseTag) {
 			std::string testUserInput = "TAG 19 #123 #abc";
 			CommandTokens actual, expected;
 			actual = _parser.parse(testUserInput);
@@ -405,7 +419,7 @@ namespace ParserTest {
 			                                      "",
 			                                      "",
 			                                      19);
-			std::vector< std::string > newTags;
+			std::vector<std::string> newTags;
 			newTags.push_back("#123");
 			newTags.push_back("#abc");
 			expected.setTags(newTags);
@@ -413,7 +427,7 @@ namespace ParserTest {
 			compareCommandTokens(expected, actual);
 		}
 
-		TEST_METHOD(unitTest_parser_TokeniseUndoCommand) {
+		TEST_METHOD(unitTest_parser_TokeniseUndo) {
 			std::string testUserInput = "UNDO";
 			CommandTokens actual, expected;
 			actual = _parser.parse(testUserInput);
@@ -427,7 +441,7 @@ namespace ParserTest {
 			compareCommandTokens(expected, actual);
 		}
 
-		TEST_METHOD(unitTest_parser_TokeniseUntagCommand) {
+		TEST_METHOD(unitTest_parser_TokeniseUntag) {
 			std::string testUserInput = "UNTAG 23 #12c #ab3";
 			CommandTokens actual, expected;
 			actual = _parser.parse(testUserInput);
@@ -437,7 +451,7 @@ namespace ParserTest {
 			                                      "",
 			                                      "",
 			                                      23);
-			std::vector< std::string > newTags;
+			std::vector<std::string> newTags;
 			newTags.push_back("#12c");
 			newTags.push_back("#ab3");
 			expected.setTags(newTags);
@@ -452,7 +466,7 @@ namespace ParserTest {
 			boost::posix_time::ptime expected(boost::posix_time::time_from_string("1999-05-13 13:20:00.000"));
 			boost::posix_time::ptime actual;
 			actual = dateParser.parse(testUserInputDate);
-			
+
 			Assert::IsTrue(expected == actual);
 		}
 
@@ -463,7 +477,7 @@ namespace ParserTest {
 			boost::posix_time::ptime expected(boost::posix_time::time_from_string("1999-05-13 00:00:00.000"));
 			boost::posix_time::ptime actual;
 			actual = dateParser.parse(testUserInputDate);
-			
+
 			Assert::IsTrue(expected == actual);
 		}
 
@@ -475,10 +489,10 @@ namespace ParserTest {
 			boost::posix_time::ptime expected(boost::posix_time::time_from_string("9999-12-31 23:59:00.000"));
 			boost::posix_time::ptime actual;
 			actual = dateParser.parse(testUserInputDate);
-			
+
 			Assert::IsTrue(expected == actual);
 		}
-		
+
 		// lower boundary case for valid date range partition
 		TEST_METHOD(unitTest_parser_DateParser_DD_MM_YYYY_HHHH_MinRange) {
 			std::string testUserInputDate = "01-01-1400 0000";
@@ -487,10 +501,10 @@ namespace ParserTest {
 			boost::posix_time::ptime expected(boost::posix_time::time_from_string("1400-01-01 00:00:00.000"));
 			boost::posix_time::ptime actual;
 			actual = dateParser.parse(testUserInputDate);
-			
+
 			Assert::IsTrue(expected == actual);
-		}		
-		
+		}
+
 		// edge cases partition: dates that are invalid because of non-uniform length of months
 		TEST_METHOD(unitTest_parser_DateParser_DD_MM_YYYY_HHHH_InvalidDate) {
 			std::string testUserInputDate = "29-02-1999 1345";
@@ -499,7 +513,7 @@ namespace ParserTest {
 			boost::posix_time::ptime expected;
 			boost::posix_time::ptime actual;
 			actual = dateParser.parse(testUserInputDate);
-			
+
 			Assert::IsTrue(expected == actual);
 		}
 

--- a/ParserTest/ParserTest.cpp
+++ b/ParserTest/ParserTest.cpp
@@ -66,6 +66,21 @@ namespace ParserTest {
 			compareCommandTokens(expected, actual);
 		}
 
+		TEST_METHOD(unitTest_parser_TokeniseConfigureSaveLocationCommand) {
+			std::string testUserInput = "CONFIGURE SAVE LOCATION D:\\";
+			CommandTokens actual, expected;
+			actual = _parser.parse(testUserInput);
+			expected = buildExpectedCommandTokens(CommandTokens::PrimaryCommandType::Configure,
+			                                      CommandTokens::SecondaryCommandType::SaveLocation,
+			                                      "",
+			                                      "",
+			                                      "",
+			                                      -1);
+			
+			expected.setOtherCommandParameter("D:\\");
+			compareCommandTokens(expected, actual);
+		}
+
 		TEST_METHOD(unitTest_parser_TokeniseDeleteFromTo) {
 			std::string testUserInput = "DELETE FROM 2002-01-20 23:59:59.000 TO 2002-01-22 23:59:59.000";
 			CommandTokens actual, expected;


### PR DESCRIPTION
- removes _commandTokens member variable
- makes tokeniseUserInput() method abstract
- renames isValidCommand() method to canTokeniseUserInput()
- also makes necessary changes to concrete sub-classes and Parser.cpp
